### PR TITLE
add forgotten password function

### DIFF
--- a/config/application.yml.example
+++ b/config/application.yml.example
@@ -1,2 +1,6 @@
 google_app_id: 'YOUR-APP-ID'
 google_app_secret: 'YOUR-APP-SECRET'
+
+
+user_name: 'YOUR-SMTP-USERNAME'
+password: 'YOUR-SMTP-PASSWORD'

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -34,7 +34,7 @@ Rails.application.configure do
   config.active_storage.service = :local
 
   # Don't care if the mailer can't send.
-  config.action_mailer.raise_delivery_errors = false
+  config.action_mailer.raise_delivery_errors = true
 
   config.action_mailer.perform_caching = false
 
@@ -73,4 +73,20 @@ Rails.application.configure do
 
   # Uncomment if you wish to allow Action Cable access from any origin.
   # config.action_cable.disable_request_forgery_protection = true
+
+  config.action_mailer.default_url_options = { host: 'localhost', port: 3000 }
+  config.assets.raise_runtime_errors = true
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.perform_deliveries = true
+  config.action_mailer.smtp_settings = {
+  address:              'smtp.mailgun.org',
+  port:                 587,
+  # domain:             'marche.com',
+  user_name:            ENV['user_name'],
+  password:             ENV['password'],
+  authentication:       'plain',
+  enable_starttls_auto: true,
+  open_timeout:         5,
+  read_timeout:         5 
+  }
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -95,14 +95,12 @@ ActiveRecord::Schema.define(version: 2023_04_19_133443) do
     t.datetime "remember_created_at"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.index ["email"], name: "index_users_on_email", unique: true
-    t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
-    
-    # 3rd-party-login
     t.string "provider"
     t.string "uid"
     t.string "name"
     t.string "avatar"
+    t.index ["email"], name: "index_users_on_email", unique: true
+    t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
   add_foreign_key "cart_products", "carts"


### PR DESCRIPTION
#4 
add `config.action_mailer` settings in `development.rb`. 
add `email` and `reset_password_token` in schema.
add SMTP-related stuff in `application.yml` files

我用這個email `astro13marche@gmail.com` 在 mailgun 辦了一個帳號，但因為目前是 free plan 還沒填信用卡資料 + 使用 sandbox domain 來做，所以現在只能寄信給 [Authorized Recipients](https://help.mailgun.com/hc/en-us/articles/217531258-Authorized-Recipients)（這邊我設定為 `astro13marche@gmail.com`，影片中的測試時也是用這個，要的話也可以在 Authorized Recipients 加上各位的信箱，但上限為五個）

`astro13marche@gmail.com` 的密碼我之後會放在 trello 裡，各位要測試收信可以使用
[測試影片](https://youtu.be/TpuOhMFe2M4)

