### PR TITLE
Seperate like feature path to 'like' and 'dislike'.

### DIFF
--- a/app/controllers/api/products_controller.rb
+++ b/app/controllers/api/products_controller.rb
@@ -1,19 +1,14 @@
 class Api::ProductsController < ApplicationController
-  before_action :set_product, only: [:like]
+  before_action :set_product, only: [:like, :dislike]
+  before_action :user_not_signed_in, only: [:like, :dislike]
   def like
-    # 未登入
-    if user_signed_in? == false
-      render json: {signInState: "false", signInUrl: new_user_session_path}
-      return
-    end
-    # 已登入
-    if current_user.like_product?(@product)
-      current_user.liked_products.destroy(@product)
-      render json: {signInState: "true", new_like_state: "dislike"}
-    else
-      current_user.liked_products << @product
-      render json: {signInState: "true", new_like_state: "like"}
-    end
+    current_user.liked_products << @product
+    render json: {signInState: "true", new_like_state: "like"}
+  end
+
+  def dislike
+    current_user.liked_products.destroy(@product)
+    render json: {signInState: "true", new_like_state: "dislike"}
   end
 
   private
@@ -23,5 +18,9 @@ class Api::ProductsController < ApplicationController
 
   def product_params
     params.require(:product).permit(:name, :description)
+  end
+
+  def user_not_signed_in
+    render json: {signInState: "false", signInUrl: new_user_session_path} if user_signed_in? == false
   end
 end

--- a/app/javascript/controllers/product/like_controller.js
+++ b/app/javascript/controllers/product/like_controller.js
@@ -19,7 +19,7 @@ export default class extends Controller {
     this.changeLikeAmount();
 
     // 打API
-    let url = `/api/products/${this.productId}/like`;
+    let url = (this.isLiked)?`/api/products/${this.productId}/like`:`/api/products/${this.productId}/dislike`
     const response = await post(url, {body: JSON.stringify({like: "like"})});
     if (response.ok) {
       const data = await response.json;

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,7 +12,10 @@ Rails.application.routes.draw do
   # like
   namespace :api do
     resources :products, only: [] do
-      member { post :like }
+      member do
+        post :like 
+        post :dislike 
+      end
     end
   end
 


### PR DESCRIPTION
將原本like api的路徑分成like & dislike，使action分工明確。