### PR TITLE
Build data transmission for shopping cart to checkout page.

### DIFF
--- a/app/controllers/carts_controller.rb
+++ b/app/controllers/carts_controller.rb
@@ -1,7 +1,8 @@
 class CartsController < ApplicationController
+  before_action :authenticate_user!
   def index
     @cart = current_user.cart
-    @cart_products = @cart.cart_products
+    @cart_products = @cart.cart_products.includes(sale_info: [:product])
   end
   
   def create
@@ -15,6 +16,14 @@ class CartsController < ApplicationController
       # render :show  這邊還要修 
     end
   end
+
+  def checkout
+    @cart = current_user.cart
+    cart_items_keys = params[:cart].delete_if{|key, value| value == '0'}.keys
+    @cart_products =  @cart.cart_products.includes(sale_info: [:product]).where(id: cart_items_keys)
+  end
+
+  private
 
   def cart_product_params
     params.require(:cart_product).permit(:quantity, :sale_info_id)

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -7,7 +7,7 @@ class ProductsController < ApplicationController
   def show
     @product_comment = ProductComment.new
     @product_comments = @product.product_comments.includes(:user).order(created_at: :desc)
-    @pagy, @records = pagy(@product_comments, items: 6, fragment: '#comment-list')
+    @pagy, @records = pagy(@product_comments, items: 9, fragment: '#comment-list')
     @sale_info = SaleInfo.find_by(product_id: @product.id)
     @cart_product = CartProduct.new
   end

--- a/app/views/carts/_item.html.erb
+++ b/app/views/carts/_item.html.erb
@@ -1,0 +1,9 @@
+<div class="m-2">
+  <%= form.check_box "#{cart_product.id}" %>
+  <%= form.label "#{cart_product.id}", "id:#{cart_product.id}", class: "bg-indigo-200"%>
+  <span class="border bg-sky-100">Product: <%= cart_product.sale_info.product.name %></span>
+  <span class="bg-indigo-200 border"><%= cart_product.sale_info.spec %></span>
+  <span class="border bg-sky-100">$<%= cart_product.sale_info.price %></span>
+  <span class="bg-indigo-200 border"><%= cart_product.quantity %></span>
+  <%= link_to '刪除商品', '#', class: "bg-rose-300 p-1 rounded hover:cursor-pointer hover:bg-rose-400" %>
+</div>

--- a/app/views/carts/checkout.html.erb
+++ b/app/views/carts/checkout.html.erb
@@ -1,0 +1,9 @@
+<h1>臨時的結帳頁面 Checkout</h1>
+<p>商品數量：<%= @cart_products.count%></p>
+<% @cart_products.each do |c| %>
+  <div class="p-1 m-1 border">
+    <span class="bg-sky-100">產品名稱: <%= c.sale_info.product.name %></span> | 
+    <span class="bg-gray-200">規格名稱: <%= c.sale_info.spec %></span> | 
+    <span class="bg-sky-100">數量：<%= c.quantity %></span>
+  </div>
+<% end %>

--- a/app/views/carts/index.html.erb
+++ b/app/views/carts/index.html.erb
@@ -1,52 +1,24 @@
 <div class="container w-full mx-auto">
-
-    <div class="container flex items-center justify-start w-11/12 m-auto mt-16 bg-gray-100 h-14">
-        <input type="checkbox" checked="checked" 
+  <div class="container flex items-center justify-start w-11/12 m-auto mt-16 bg-gray-100 h-14">
+    <input type="checkbox" checked="checked" 
         class="ml-6 mr-4 checkbox checkbox-primary" />
-        <p class="mr-2 text-sm w-96">商品</p>
-        <p class="mr-2 text-sm text-center w-28">單價</p>
-        <p class="w-40 mr-2 text-sm text-center">數量</p>
-        <p class="mr-2 text-sm text-center w-28">總計</p>
-        <p class="mr-6 text-sm text-center w-28">操作</p>
-    </div>
-
-    <div class="container flex items-center w-11/12 m-auto mt-3 bg-gray-100 border-b border-gray-300 h-14">
-        <input type="checkbox" checked="checked" 
-        class="ml-6 mr-4 checkbox checkbox-primary" />
-        <p class="mr-2 text-sm link link-hover w-96 hover:no-underline">賣家名稱賣家名稱</p>
-    </div>
-
-    <% @cart_products.each do |c| %>
-        <section class="container flex items-center w-11/12 m-auto bg-gray-100 border-b border-gray-300 h-28">
-            <input type="checkbox" checked="checked" 
-            class="ml-6 mr-4 checkbox checkbox-primary" />
-            <img src="https://picsum.photos/80/" class="w-20 h-20 mr-4 link link-hover">
-            <p class="block mr-3 text-sm hover:no-underline w-36 link link-hover"><%= c.sale_info.product.name %></p>
-            <div class="w-32 mr-3 dropdown">
-                <label tabindex="0" class="text-sm font-light link link-hover hover:no-underline"><%= c.sale_info.spec %> <span class="text-xs text-gray-500">▼</span> <br>規格名稱描述ABC</label>
-                <ul tabindex="0" class="p-2 text-sm shadow dropdown-content menu bg-base-100 rounded-box w-52">
-                    <li><a>規格名稱AAA</a></li>
-                    <li><a>規格名稱BBB</a></li>
-                    <li><a>規格名稱CCC</a></li>
-                </ul>
-            </div>
-            <p class="mr-2 text-sm font-semibold text-center w-28"><%= c.sale_info.price %></p>
-            <div class="flex justify-center w-40">
-                <button class="text-lg leading-6 text-gray-400 border border-gray-300 w-7 ">－</button>
-                <p class="self-center px-4 text-base text-center border border-gray-300"><%= c.quantity %></p>
-                <button class="text-lg leading-6 text-gray-400 border border-gray-300 w-7">＋</button>
-            </div>
-            <p class="mr-2 text-sm font-semibold text-center text-indigo-600 w-28">$9,999,999</p>
-            <p class="mr-6 text-sm text-center w-28 link link-hover hover:no-underline">刪除</p>
-        </section>
+    <p class="mr-2 text-sm w-96">商品</p>
+    <p class="mr-2 text-sm text-center w-28">單價</p>
+    <p class="w-40 mr-2 text-sm text-center">數量</p>
+    <p class="mr-2 text-sm text-center w-28">總計</p>
+    <p class="mr-6 text-sm text-center w-28">操作</p>
+  </div>
+  <section class="p-2 m-2 border bg-gay-200">
+    <%= form_with model: @cart,  url: checkout_path, method: :get, data: { turbo: "false" } do |form| %>
+      <%= render partial:'carts/item', collection: @cart_products , as: :cart_product, locals: {form: form} %>
+      <%= form.submit "買單", class: "bg-lime-500 hover:bg-lime-600 hover:cursor-pointer p-2 m-2 rounded text-white"%>
     <% end %>
-
-    <div class="container flex items-center w-11/12 h-20 m-auto mt-6 bg-gray-100">
-        <input type="checkbox" checked="checked" 
+  </section>
+  <div class="container flex items-center w-11/12 h-20 m-auto mt-6 bg-gray-100">
+    <input type="checkbox" checked="checked" 
         class="ml-6 mr-4 checkbox checkbox-primary" />
-        <p class="mr-8 text-sm w-96">全選 (99)</p>
-        <p class="mr-3 text-sm w-fit ms-auto">總金額 (99 個商品) :<span class="ml-1 text-lg font-semibold text-indigo-600">$9,999,999</span></p>
-        <button class="px-12 mr-6 btn btn-primary">去買單</button>
-    </div>
-    
+    <p class="mr-8 text-sm w-96">全選 (99)</p>
+    <p class="mr-3 text-sm w-fit ms-auto">總金額 (99 個商品) :<span class="ml-1 text-lg font-semibold text-indigo-600">$9,999,999</span></p>
+    <button class="px-12 mr-6 btn btn-primary">去買單</button>
+  </div>
 </div>

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -13,12 +13,10 @@
           <strong class="block mb-1 font-medium">商品名稱:</strong>
           <%= @product.name %>
         </p>
-
         <p class="my-5">
           <strong class="block mb-1 font-medium" >價格:</strong>
           <%= @sale_info.price %>
         </p>
-
         <p class="my-5">
           <%= form_with(model: @cart_product, url: cart_path, method: :post, data: { turbo: false }) do |form| %>
             <div class="flex">
@@ -28,22 +26,17 @@
             還剩<%= @sale_info.storage %>件
             <%= form.submit "加入購物車", class: "ml-4 bg-blue-500 text-white px-4 py-2 rounded-full hover:bg-blue-600" %>
           <% end %>
-
         </p>
       </div>
     </div>
-
     <section class="my-5">
       <strong class="block mb-1 font-medium">規格:</strong>
       <%= @sale_info.spec %>
     </section>
-
     <section class="my-5">
       <strong class="block mb-1 font-medium">描述:</strong>
       <%= @product.description %>
     </section>
-    
-
     <%= link_to '編輯此商品', edit_product_path(@product), class: "mt-2 rounded-lg py-3 px-5 bg-gray-100 inline-block font-medium" %>
     <div class="inline-block ml-2">
       <%= button_to '刪除此商品', product_path(@product), method: :delete, class: "mt-2 rounded-lg py-3 px-5 bg-gray-100 font-medium" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,6 +22,7 @@ Rails.application.routes.draw do
   # carts
   post '/cart', to: 'carts#create'
   get '/cart', to: 'carts#index'
+  get '/checkout', to: 'carts#checkout'
   
   # categories
   resources :categories


### PR DESCRIPTION
# 建立購物車到結帳頁面的傳輸功能，勾選的商品項目將顯示於結帳頁面。
使用方式：
在會員登入狀態下將多項不同商品加入購物車 > 在購物車頁面勾選想要購買的商品 > 按下“買單”按鈕
購物車頁面：
<img width="769" alt="截圖 2023-04-29 下午5 59 07" src="https://user-images.githubusercontent.com/71165941/235297396-bbfa2321-b380-4edd-850a-0a028b4ec959.png">
臨時結帳頁面：
<img width="566" alt="截圖 2023-04-29 下午5 59 19" src="https://user-images.githubusercontent.com/71165941/235297416-3acfe0c3-05d0-4ec5-907b-207e69318256.png">

進階說明：
- 目前購物車頁面僅可供使用者勾選要哪些產品，還不能更換規格、改變數量、刪除項目
- 使用form.check_box的helper傳遞資訊，Parameters: {"cart"=>{"7"=>"1", "8"=>"0", "9"=>"1"}, "commit"=>"買單"}，cart的第一個key是指cart_product的id，後面的1 or 0 代表有沒有被勾選
- 程式中使用includes避免n+1問題