### PR TITLE
數量api功能

### DIFF
--- a/app/controllers/api/carts_controller.rb
+++ b/app/controllers/api/carts_controller.rb
@@ -1,0 +1,16 @@
+class Api::CartsController < ApplicationController
+
+  def edit
+    @cart_product = CartProduct.find(params[:id])
+    storage = @cart_product.sale_info.storage
+    if params[:quantity] < 0 || params[:quantity] > storage 
+      render json: {state: "fail"}
+      return
+    else
+      @cart_product.quantity = params[:quantity]
+      @cart_product.save
+      render json: {state: "success"}
+    end
+  end
+  
+end

--- a/app/helpers/api/carts_helper.rb
+++ b/app/helpers/api/carts_helper.rb
@@ -1,0 +1,2 @@
+module Api::CartsHelper
+end

--- a/app/javascript/controllers/cart/item_controller.js
+++ b/app/javascript/controllers/cart/item_controller.js
@@ -1,12 +1,13 @@
 import {Controller} from "@hotwired/stimulus";
+import {post} from "@rails/request.js";
 
 // Connects to data-controller="cart--item"
 export default class extends Controller {
   static targets = ["quantity", "inputArea", "itemTotalPrice", "checkbox"];
   connect() {
+    this.cartProductId = this.element.dataset.cartProductId;
     this.quantityNum = Number(this.quantityTarget.value);
     this.storageNum = Number(this.quantityTarget.dataset.storage);
-    console.log(this.storageNum);
     if (this.storageNum <= 0) this.disableComponents(); // 庫存為0
     this.updateItemTotalPrice();
   }
@@ -20,11 +21,13 @@ export default class extends Controller {
     }
     this.quantityNum = 0;
     this.setQuantityTarget();
+    this.updateCartProductQuantityViaAPI();
   }
   // User typing quantity
   updateQuantity() {
     this.quantityNum = Math.floor(this.quantityTarget.value);
     this.setQuantityTarget();
+    this.updateCartProductQuantityViaAPI();
   }
   // + button pressed
   increment(e) {
@@ -34,6 +37,7 @@ export default class extends Controller {
       this.upperOpacity();
       this.quantityNum += 1;
       this.setQuantityTarget();
+      this.updateCartProductQuantityViaAPI();
     }, 100);
   }
   // - button pressed
@@ -44,6 +48,7 @@ export default class extends Controller {
       this.upperOpacity();
       this.quantityNum -= 1;
       this.setQuantityTarget();
+      this.updateCartProductQuantityViaAPI();
     }, 100);
   }
   // lower opacity for flashing input area
@@ -82,5 +87,15 @@ export default class extends Controller {
     }
     this.quantityTarget.value = this.quantityNum;
     this.updateItemTotalPrice();
+  }
+  async updateCartProductQuantityViaAPI() {
+    let url = `/api/carts/${this.cartProductId}/edit`;
+    const response = await post(url, {
+      body: JSON.stringify({quantity: this.quantityNum}),
+    });
+    if (response.ok) {
+      const data = await response.json;
+      // console.log(data);
+    }
   }
 }

--- a/app/views/carts/_item.html.erb
+++ b/app/views/carts/_item.html.erb
@@ -1,4 +1,4 @@
-<div class="container flex items-center justify-start w-11/12 m-2" data-controller="cart--item">
+<div class="container flex items-center justify-start w-11/12 m-2" data-controller="cart--item" data-cart-product-id="<%=cart_product.id%>">
   <%= form.check_box "#{cart_product.id}", class: "checkbox checkbox-sm rounded m-3", data: {cart__item_target: "checkbox"} %>
   <div class="w-20 h-20 m-3 bg-slate-300">
     <img src="https://picsum.photos/80/80/?random=12" class=''>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,9 +20,10 @@ Rails.application.routes.draw do
   
     #category
     post '/categories', to: 'categories#assign'
-  end
 
-  #
+    # cart
+    post '/carts/:id/edit', to: 'carts#edit', as: :carts_edit
+  end
 
   # carts
   post '/cart', to: 'carts#create'


### PR DESCRIPTION
使用方式：透過輸入商品數量、點擊+ - 按鈕，前端會打API到後端更新資料庫，重新刷新頁面可確認數量確實有被記錄。
進階說明：
- quantity除了在前端做確認，後端的controller也會做一次確認
- 數量欄位只要有變動就會打api，如果使用者狂按對後端的負擔有點大，之後有時間可以開發throttle or debounce功能