### PR TITLE
購物車總價計算功能、庫存提醒功能、修正原先form checkbox的寫法

### DIFF
--- a/app/controllers/carts_controller.rb
+++ b/app/controllers/carts_controller.rb
@@ -19,8 +19,7 @@ class CartsController < ApplicationController
 
   def checkout
     @cart = current_user.cart
-    cart_items_keys = params[:cart].delete_if{|key, value| value == '0'}.keys
-    @cart_products =  @cart.cart_products.includes(sale_info: [:product]).where(id: cart_items_keys)
+    @cart_products =  @cart.cart_products.includes(sale_info: [:product]).where(id: params[:cart_product_ids])
   end
 
   def destroy

--- a/app/javascript/controllers/cart/form_controller.js
+++ b/app/javascript/controllers/cart/form_controller.js
@@ -2,14 +2,58 @@ import {Controller} from "@hotwired/stimulus";
 
 // Connects to data-controller="cart--form"
 export default class extends Controller {
+  static targets = ["checkbox", "itemTotalPrice", "totalPrice", "productNum"];
   connect() {
     // form表單預設會找尋第一個submit or button進行click事件，因此要preventDefault
     this.element.setAttribute(
       "data-action",
-      "keydown.enter->cart--form#submit"
+      "keydown.enter->cart--form#preventSubmit"
     );
+    this.isAllChecked = false;
   }
-  submit(e) {
+  update() {
+    let sum = 0;
+    let checkedNum = 0;
+    for (let i = 0; i < this.checkboxTargets.length; i++) {
+      if (this.checkboxTargets[i].checked) {
+        sum += this.convertMoneyToNumber(
+          this.itemTotalPriceTargets[i].textContent
+        );
+        checkedNum += 1;
+      }
+    }
+    this.totalPriceTarget.textContent = this.formatMoney(sum);
+    this.productNumTarget.textContent = checkedNum;
+  }
+  boxChecked() {}
+  totalPriceChanged() {}
+  convertMoneyToNumber(price) {
+    return Number(price.split("$")[1].split(",").join(""));
+  }
+  preventSubmit(e) {
     e.preventDefault();
+  }
+  formatMoney(price) {
+    let integerPart = price.toString().split(".")[0].split("").reverse();
+    for (let i = 3; i < integerPart.length; i += 4) {
+      integerPart.splice(i, 0, ",");
+    }
+    let decimalPart = price.toString().split(".")[1];
+    decimalPart = decimalPart == undefined ? "" : `.${decimalPart}`;
+    return `$${integerPart.reverse().join("")}${decimalPart}`;
+  }
+  checkAllBox() {
+    if (this.isAllChecked) {
+      this.isAllChecked = false;
+      for (let i = 0; i < this.checkboxTargets.length; i++) {
+        this.checkboxTargets[i].checked = false;
+      }
+    } else {
+      this.isAllChecked = true;
+      for (let i = 0; i < this.checkboxTargets.length; i++) {
+        this.checkboxTargets[i].checked = true;
+      }
+    }
+    this.update();
   }
 }

--- a/app/javascript/controllers/cart/item_controller.js
+++ b/app/javascript/controllers/cart/item_controller.js
@@ -3,7 +3,13 @@ import {post} from "@rails/request.js";
 
 // Connects to data-controller="cart--item"
 export default class extends Controller {
-  static targets = ["quantity", "inputArea", "itemTotalPrice", "checkbox"];
+  static targets = [
+    "quantity",
+    "inputArea",
+    "itemTotalPrice",
+    "checkbox",
+    "storageWarning",
+  ];
   connect() {
     this.cartProductId = this.element.dataset.cartProductId;
     this.quantityNum = Number(this.quantityTarget.value);
@@ -87,7 +93,20 @@ export default class extends Controller {
     }
     this.quantityTarget.value = this.quantityNum;
     this.updateItemTotalPrice();
+    // 庫存提示
+    if (this.quantityNum == this.storageNum) {
+      this.revealStorageWarning();
+    } else {
+      this.hiddenStorageWarning();
+    }
   }
+  hiddenStorageWarning() {
+    this.storageWarningTarget.classList.add("hidden");
+  }
+  revealStorageWarning() {
+    this.storageWarningTarget.classList.remove("hidden");
+  }
+  // API
   async updateCartProductQuantityViaAPI() {
     let url = `/api/carts/${this.cartProductId}/edit`;
     const response = await post(url, {

--- a/app/views/carts/_item.html.erb
+++ b/app/views/carts/_item.html.erb
@@ -1,5 +1,5 @@
 <div class="container flex items-center justify-start w-11/12 m-2" data-controller="cart--item" data-cart-product-id="<%=cart_product.id%>">
-  <%= form.check_box "#{cart_product.id}", class: "checkbox checkbox-sm rounded m-3", data: {cart__item_target: "checkbox"} %>
+  <%= check_box_tag "cart_product_ids[]", cart_product.id, false, id: "cart_product_#{cart_product.id}", class: "checkbox checkbox-sm rounded m-3" , data: {cart__item_target: "checkbox"} %>
   <div class="w-20 h-20 m-3 bg-slate-300">
     <img src="https://picsum.photos/80/80/?random=12" class=''>
   </div>

--- a/app/views/carts/_item.html.erb
+++ b/app/views/carts/_item.html.erb
@@ -16,10 +16,11 @@
   <%# 單價 %>
   <div class="m-1">$<%= cart_product.sale_info.price %></div>
   <%# 數量 %>
-  <div class="flex items-center m-2" data-cart--item-target="inputArea">
+  <div class="relative flex items-center m-2" data-cart--item-target="inputArea">
     <button class="quantity-btn-left-arrow" data-action="click->cart--item#decrement click->cart--form#update">－</button>
     <input type="number" class="quantity-btn-center-input" value="<%= cart_product.quantity %>" data-cart--item-target="quantity" data-action="change->cart--item#updateQuantity change->cart--form#update" data-storage="<%=cart_product.sale_info.storage%>">
     <button class="quantity-btn-right-arrow" data-action="click->cart--item#increment click->cart--form#update">＋</button>
+    <p class="absolute hidden text-xs font-bold text-rose-400 left-1/4 top-full" data-cart--item-target="storageWarning">庫存：<%= cart_product.sale_info.storage %></p>
   </div>
   <%# 總價 ＝ 單價 x 數量 %>
   <div class="flex items-center justify-end w-20 m-2 text-amber-500" data-cart--item-target="itemTotalPrice" data-unit-price="<%= cart_product.sale_info.price %>" data-cart--form-target="itemTotalPrice">$?</div>

--- a/app/views/carts/_item.html.erb
+++ b/app/views/carts/_item.html.erb
@@ -1,5 +1,7 @@
 <div class="container flex items-center justify-start w-11/12 m-2" data-controller="cart--item" data-cart-product-id="<%=cart_product.id%>">
-  <%= check_box_tag "cart_product_ids[]", cart_product.id, false, id: "cart_product_#{cart_product.id}", class: "checkbox checkbox-sm rounded m-3" , data: {cart__item_target: "checkbox"} %>
+  <%# checkbox %>
+  <%= check_box_tag "cart_product_ids[]", cart_product.id, false, id: "cart_product_#{cart_product.id}", class: "checkbox checkbox-sm rounded m-3" , data: {cart__item_target: "checkbox", cart__form_target: "checkbox", action: "change->cart--form#update"} %>
+  <%# 商品圖片 %>
   <div class="w-20 h-20 m-3 bg-slate-300">
     <img src="https://picsum.photos/80/80/?random=12" class=''>
   </div>
@@ -15,12 +17,12 @@
   <div class="m-1">$<%= cart_product.sale_info.price %></div>
   <%# 數量 %>
   <div class="flex items-center m-2" data-cart--item-target="inputArea">
-    <button class="quantity-btn-left-arrow" data-action="click->cart--item#decrement">－</button>
-    <input type="number" class="quantity-btn-center-input" value="<%= cart_product.quantity %>" data-cart--item-target="quantity" data-action="change->cart--item#updateQuantity" data-storage="<%=cart_product.sale_info.storage%>">
-    <button class="quantity-btn-right-arrow" data-action="click->cart--item#increment">＋</button>
+    <button class="quantity-btn-left-arrow" data-action="click->cart--item#decrement click->cart--form#update">－</button>
+    <input type="number" class="quantity-btn-center-input" value="<%= cart_product.quantity %>" data-cart--item-target="quantity" data-action="change->cart--item#updateQuantity change->cart--form#update" data-storage="<%=cart_product.sale_info.storage%>">
+    <button class="quantity-btn-right-arrow" data-action="click->cart--item#increment click->cart--form#update">＋</button>
   </div>
   <%# 總價 ＝ 單價 x 數量 %>
-  <div class="flex items-center justify-end w-20 m-2 text-amber-500" data-cart--item-target="itemTotalPrice" data-unit-price="<%= cart_product.sale_info.price %>">$?</div>
+  <div class="flex items-center justify-end w-20 m-2 text-amber-500" data-cart--item-target="itemTotalPrice" data-unit-price="<%= cart_product.sale_info.price %>" data-cart--form-target="itemTotalPrice">$?</div>
   <%= link_to cart_destroy_path(cart_product.id), method: :delete, data: {confirm: "確定要刪除該商品？"} do %>
     <i class="p-1 m-1 text-red-500 rounded bg-neutral-100 drop-shadow fa-regular fa-trash-can"></i>
   <% end %>

--- a/app/views/carts/index.html.erb
+++ b/app/views/carts/index.html.erb
@@ -9,11 +9,11 @@
     <p class="mr-2 text-sm text-center w-28">總計</p>
     <p class="mr-6 text-sm text-center w-28">操作</p>
   </div>
-  <%= form_with model: @cart,  url: checkout_path, method: :get, data: { turbo: "false", controller: "cart--form" } do |form| %>
-    <%= render partial:'carts/item', collection: @cart_products , as: :cart_product, locals: {form: form} %>
+  <%= form_with url: checkout_path, method: :get, data: { turbo: "false", controller: "cart--form" } do |form| %>
+    <%= render partial:'carts/item', collection: @cart_products , as: :cart_product%>
     <div class="container flex items-center h-20 bg-gray-100">
       <input type="checkbox" checked="checked" 
-        class="ml-6 mr-4 checkbox checkbox-primary" />
+        class="ml-6 mr-4 checkbox checkbox-primary"/>
       <p class="mr-8 text-sm w-96">全選 (<span>0</span>)</p>
       <p class="mr-3 text-sm w-fit ms-auto">總金額 (<span>0</span> 個商品) :<span class="m-2 text-lg font-semibold text-orange-600">$0</span></p>
       <%= form.submit "去買單", class: "bg-orange-500 hover:bg-orange-600 hover:cursor-pointer p-2 m-2 rounded text-white text-sm w-28"%>

--- a/app/views/carts/index.html.erb
+++ b/app/views/carts/index.html.erb
@@ -1,21 +1,19 @@
 <%# <div class="container w-full mx-auto"> %>
 <section class="container w-11/12 m-auto border bg-gay-200">
-  <div class="flex items-center justify-start bg-gray-100 h-14">
-    <input type="checkbox" checked="checked" 
-        class="ml-6 mr-4 checkbox checkbox-primary" />
-    <p class="mr-2 text-sm w-96">商品</p>
-    <p class="mr-2 text-sm text-center w-28">單價</p>
-    <p class="w-40 mr-2 text-sm text-center">數量</p>
-    <p class="mr-2 text-sm text-center w-28">總計</p>
-    <p class="mr-6 text-sm text-center w-28">操作</p>
-  </div>
   <%= form_with url: checkout_path, method: :get, data: { turbo: "false", controller: "cart--form" } do |form| %>
+    <div class="flex items-center justify-start bg-gray-100 h-14">
+      <p class="m-2 text-sm w-96">商品</p>
+      <p class="mr-2 text-sm text-center w-28">單價</p>
+      <p class="w-40 mr-2 text-sm text-center">數量</p>
+      <p class="mr-2 text-sm text-center w-28">總計</p>
+      <p class="mr-6 text-sm text-center w-28">操作</p>
+    </div>
     <%= render partial:'carts/item', collection: @cart_products , as: :cart_product%>
     <div class="container flex items-center h-20 bg-gray-100">
-      <input type="checkbox" checked="checked" 
-        class="ml-6 mr-4 checkbox checkbox-primary"/>
-      <p class="mr-8 text-sm w-96">全選 (<span>0</span>)</p>
-      <p class="mr-3 text-sm w-fit ms-auto">總金額 (<span>0</span> 個商品) :<span class="m-2 text-lg font-semibold text-orange-600">$0</span></p>
+      <input type="checkbox"  
+        class="ml-6 mr-4 checkbox checkbox-primary" data-action="change->cart--form#checkAllBox"/>
+      <p class="mr-8 text-sm w-96">全選 (<%= @cart_products.count %>)</p>
+      <p class="mr-3 text-sm w-fit ms-auto">總金額 (<span data-cart--form-target="productNum">0</span> 個商品) :<span class="m-2 text-lg font-semibold text-orange-600" data-cart--form-target="totalPrice">$0</span></p>
       <%= form.submit "去買單", class: "bg-orange-500 hover:bg-orange-600 hover:cursor-pointer p-2 m-2 rounded text-white text-sm w-28"%>
     <% end %>
   </div>


### PR DESCRIPTION
**請先讓cart_v3分支的PR通過再審cart_v4**
使用方式：將商品加入購物車後，點擊選取按鈕，購物車下方會即時計算有勾選的商品總價，數量欄位數量變動時也會即時計算。當使用者的購買數量與當前庫存相同時，數量選取框的下方會有紅色的提示字。
<img width="1298" alt="截圖 2023-05-03 上午12 09 15" src="https://user-images.githubusercontent.com/71165941/235725318-4140cb82-a681-4fa4-98bb-f5d855f5a26f.png">
進階說明：
- 購物車checkbox的方式改成使用check_box_tag，傳輸的格式簡化成cart_product_ids"=>["7", "8"]
- 購物車前端使用兩個controller，item_controller包在每個購物項目中，form_controller包在整個form_with中，主要負責總選取&總價計算