### PR TITLE
微調登入和註冊頁面樣式

### DIFF
--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -17,22 +17,22 @@
       <div class="field mb-3">
         <%= f.label :email ,"會員帳號" ,class: "leading-loose text-sm text-zinc-500" %>
         <br/>
-        <%= f.email_field :email, autofocus: true, autocomplete: "e-mail" ,class: "w-full bg-marche_pearl rounded-md border-0 leading-tight " ,placeholder: "請輸入您的e-mail" %>
+        <%= f.email_field :email, autofocus: true, autocomplete: "e-mail" ,class: "w-full bg-marche_pearl rounded-md border-0 leading-tight active:ring active:ring-zinc-300 focus:ring-2 focus:ring-zinc-300" ,placeholder: "請輸入您的e-mail" %>
       </div>
 
       <div class="field mb-3">
         <%= f.label :password ,"輸入密碼" ,class: "leading-loose text-sm text-zinc-500" %>
         <br />
-        <%= f.password_field :password, autocomplete: "new-password" ,class: "w-full bg-marche_pearl rounded-md border-0 leading-tight" ,placeholder: "最少6個字符" %>
+        <%= f.password_field :password, autocomplete: "new-password" ,class: "w-full bg-marche_pearl rounded-md border-0 leading-tight active:ring active:ring-zinc-300 focus:ring-2 focus:ring-zinc-300" ,placeholder: "最少6個字符" %>
       </div>
 
       <div class="field mb-4">
         <%= f.label :password_confirmation ,"確認密碼" ,class: "leading-loose text-sm text-zinc-500" %><br />
-        <%= f.password_field :password_confirmation, autocomplete: "new-password" ,class: "w-full bg-marche_pearl rounded-md border-0 leading-tight", placeholder: "請再次輸入您的密碼" %>
+        <%= f.password_field :password_confirmation, autocomplete: "new-password" ,class: "w-full bg-marche_pearl rounded-md border-0 leading-tight active:ring active:ring-zinc-300 focus:ring-2 focus:ring-zinc-300", placeholder: "請再次輸入您的密碼" %>
       </div>
 
       <div class="action mb-4">
-        <%= f.submit "註冊", class: " w-full text-lg p-2 bg-marche_orange rounded-lg text-marche_white" %>
+        <%= f.submit "註冊", class: " w-full text-lg p-2 bg-marche_orange rounded-lg text-marche_white cursor-pointer hover:bg-orange-600" %>
       </div>
       <%= render "devise/shared/links" %>
     <% end %>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,26 +1,47 @@
-<h2>Log in</h2>
-
-<%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+<div class="flex w-full bg-marche_white items-center h-15">
+  <div class="bg-rose-300 bg-opacity-0 w-20 h-12 m-5">
+    <%= image_tag "marche_logo.svg" ,class: "h-full" %>
   </div>
-
-  <div class="field">
-    <%= f.label :password %><br />
-    <%= f.password_field :password, autocomplete: "current-password" %>
+  <h2 class="text-slate-600 text-lg">登入</h2>
+</div>
+<div class="w-full flex py-16 flex-col sm:flex-row justify-evenly items-center bg-marche_orange ">
+  <%# logo %>
+  <div class="bg-rose-300 bg-opacity-0 w-80 h-80 flex justify-center items-center"> 
+    <%= image_tag "marche_logo_orangewhite.png"%>
   </div>
+  <%# 輸入框 %>
+  <div class="w-[337px] bg-marche_white rounded-xl flex justify-center items-center">
+    <%= form_for(resource, as: resource_name, url: session_path(resource_name),html: {class: "p-6 w-[305px]"} )  do |f| %>
+      <%= render "devise/shared/error_messages", resource: resource %>
+      <h3 class="text-left text-2xl font-bold text-slate-500 mb-3">登入</h3>
+        <div class="field mb-3">
+          <%= f.label :email ,"會員帳號" ,class: "leading-loose text-sm text-zinc-500" %>
+          <br />
+          <%= f.email_field :email, autofocus: true, autocomplete: "email" ,class: "w-full bg-marche_pearl rounded-md border-0 leading-tight " ,placeholder: "請輸入您的e-mail" %>
+        </div>
+        <div class="field mb-3">
+          <%= f.label :password ,"輸入密碼" ,class: "leading-loose text-sm text-zinc-500" %>
+          <br/>
+          <%= f.password_field :password, autocomplete: "current-password" ,class: "w-full bg-marche_pearl rounded-md border-0 leading-tight" ,placeholder: "最少6個字符" %>
+        </div>
 
-  <% if devise_mapping.rememberable? %>
-    <div class="field">
-      <%= f.check_box :remember_me %>
-      <%= f.label :remember_me %>
-    </div>
-  <% end %>
+        <% if devise_mapping.rememberable? %>
+          <div class="field">
+            <%= f.check_box :remember_me ,class: "rounded border-2 border-zinc-400" %>
+            <%= f.label :remember_me ,"記住我的帳號" ,class: "leading-loose text-sm text-zinc-500" %>
+          </div>
+        <% end %>
 
-  <div class="actions">
-    <%= f.submit "Log in" %>
+        <div class="actions pt-5 pb-5 flex justify-center">
+          <%= f.submit "登入", class: "w-full text-lg p-2 bg-marche_orange rounded-lg text-marche_white" %>
+        </div>
+        <div class="btn flex justify-center">
+          <%- if devise_mapping.omniauthable? %>
+            <%- resource_class.omniauth_providers.each do |provider| %>
+              <%= button_to "使用Google登入", omniauth_authorize_path(resource_name, provider), data: { turbo: false }, class: "tracking-wide" %><br />
+            <% end %>
+          <% end %>
+        </div>
+    <% end %>
   </div>
-<% end %>
-
-<%= render "devise/shared/links" %>
+</div>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -17,23 +17,23 @@
         <div class="field mb-3">
           <%= f.label :email ,"會員帳號" ,class: "leading-loose text-sm text-zinc-500" %>
           <br />
-          <%= f.email_field :email, autofocus: true, autocomplete: "email" ,class: "w-full bg-marche_pearl rounded-md border-0 leading-tight " ,placeholder: "請輸入您的e-mail" %>
+          <%= f.email_field :email, autofocus: true, autocomplete: "email" ,class: "w-full bg-marche_pearl rounded-md border-0 leading-tight active:ring active:ring-zinc-300 focus:ring-2 focus:ring-zinc-300" ,placeholder: "請輸入您的e-mail" %>
         </div>
         <div class="field mb-3">
           <%= f.label :password ,"輸入密碼" ,class: "leading-loose text-sm text-zinc-500" %>
           <br/>
-          <%= f.password_field :password, autocomplete: "current-password" ,class: "w-full bg-marche_pearl rounded-md border-0 leading-tight" ,placeholder: "最少6個字符" %>
+          <%= f.password_field :password, autocomplete: "current-password" ,class: "w-full bg-marche_pearl rounded-md border-0 leading-tight active:ring active:ring-zinc-300 focus:ring-2 focus:ring-zinc-300" ,placeholder: "最少6個字符" %>
         </div>
 
         <% if devise_mapping.rememberable? %>
           <div class="field">
-            <%= f.check_box :remember_me ,class: "rounded border-2 border-zinc-400" %>
+            <%= f.check_box :remember_me ,class: "rounded border-2 border-zinc-400 focus:ring-marche_orange" %>
             <%= f.label :remember_me ,"記住我的帳號" ,class: "leading-loose text-sm text-zinc-500" %>
           </div>
         <% end %>
 
         <div class="actions pt-5 pb-5 flex justify-center">
-          <%= f.submit "登入", class: "w-full text-lg p-2 bg-marche_orange rounded-lg text-marche_white" %>
+          <%= f.submit "登入", class: "w-full text-lg p-2 bg-marche_orange rounded-lg text-marche_white cursor-pointer hover:bg-orange-600" %>
         </div>
         <div class="btn flex justify-center">
           <%- if devise_mapping.omniauthable? %>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -11,37 +11,37 @@
   </div>
   <%# 輸入框 %>
   <div class="w-[337px] bg-marche_white rounded-xl flex justify-center items-center">
-    <%= form_for(resource, as: resource_name, url: session_path(resource_name),html: {class: "p-6 w-[305px]"} )  do |f| %>
+    <%= form_for(resource, as: resource_name, url: session_path(resource_name),html: {class: "p-[37.99px] w-[305px]"} )  do |f| %>
       <%= render "devise/shared/error_messages", resource: resource %>
       <h3 class="text-left text-2xl font-bold text-slate-500 mb-3">登入</h3>
-        <div class="field mb-3">
-          <%= f.label :email ,"會員帳號" ,class: "leading-loose text-sm text-zinc-500" %>
-          <br />
-          <%= f.email_field :email, autofocus: true, autocomplete: "email" ,class: "w-full bg-marche_pearl rounded-md border-0 leading-tight active:ring active:ring-zinc-300 focus:ring-2 focus:ring-zinc-300" ,placeholder: "請輸入您的e-mail" %>
+      <div class="field mb-3">
+        <%= f.label :email ,"會員帳號" ,class: "leading-loose text-sm text-zinc-500" %>
+        <br />
+        <%= f.email_field :email, autofocus: true, autocomplete: "email" ,class: "w-full bg-marche_pearl rounded-md border-0 leading-tight active:ring active:ring-zinc-300 focus:ring-2 focus:ring-zinc-300" ,placeholder: "請輸入您的e-mail" %>
+      </div>
+      <div class="field mb-3">
+        <%= f.label :password ,"輸入密碼" ,class: "leading-loose text-sm text-zinc-500" %>
+        <br/>
+        <%= f.password_field :password, autocomplete: "current-password" ,class: "w-full bg-marche_pearl rounded-md border-0 leading-tight active:ring active:ring-zinc-300 focus:ring-2 focus:ring-zinc-300" ,placeholder: "最少6個字符" %>
+      </div>
+      
+      <% if devise_mapping.rememberable? %>
+        <div class="field">
+          <%= f.check_box :remember_me ,class: "rounded border-2 border-zinc-400 focus:ring-marche_orange" %>
+          <%= f.label :remember_me ,"記住我的帳號" ,class: "leading-loose text-sm text-zinc-500" %>
         </div>
-        <div class="field mb-3">
-          <%= f.label :password ,"輸入密碼" ,class: "leading-loose text-sm text-zinc-500" %>
-          <br/>
-          <%= f.password_field :password, autocomplete: "current-password" ,class: "w-full bg-marche_pearl rounded-md border-0 leading-tight active:ring active:ring-zinc-300 focus:ring-2 focus:ring-zinc-300" ,placeholder: "最少6個字符" %>
-        </div>
+      <% end %>
 
-        <% if devise_mapping.rememberable? %>
-          <div class="field">
-            <%= f.check_box :remember_me ,class: "rounded border-2 border-zinc-400 focus:ring-marche_orange" %>
-            <%= f.label :remember_me ,"記住我的帳號" ,class: "leading-loose text-sm text-zinc-500" %>
-          </div>
-        <% end %>
-
-        <div class="actions pt-5 pb-5 flex justify-center">
-          <%= f.submit "登入", class: "w-full text-lg p-2 bg-marche_orange rounded-lg text-marche_white cursor-pointer hover:bg-orange-600" %>
-        </div>
-        <div class="btn flex justify-center">
-          <%- if devise_mapping.omniauthable? %>
-            <%- resource_class.omniauth_providers.each do |provider| %>
-              <%= button_to "使用Google登入", omniauth_authorize_path(resource_name, provider), data: { turbo: false }, class: "tracking-wide" %><br />
-            <% end %>
+      <div class="actions pt-5 pb-5 flex justify-center">
+        <%= f.submit "登入", class: "w-full text-lg p-2 bg-marche_orange rounded-lg text-marche_white cursor-pointer hover:bg-orange-600" %>
+      </div>
+      <div class="btn flex justify-center">
+        <%- if devise_mapping.omniauthable? %>
+          <%- resource_class.omniauth_providers.each do |provider| %>
+            <%= button_to "使用Google登入", omniauth_authorize_path(resource_name, provider), data: { turbo: false }, class: "tracking-wide" %><br />
           <% end %>
-        </div>
+        <% end %>
+      </div>
     <% end %>
   </div>
 </div>

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -18,8 +18,8 @@
         <% else %>
           <li class="py-1 pl-4 text-marche_orange text-md">您現在為訪客</li>
           <li>
-            <%= link_to "註冊", new_user_registration_path %>
-            <%= link_to "登入", new_user_session_path %>
+            <%= link_to "註冊", new_user_registration_path, class: "active:bg-marche_orange" %>
+            <%= link_to "登入", new_user_session_path, class: "active:bg-marche_orange" %>
           </li>
         <% end %>
       </ul>


### PR DESCRIPTION
微調：
1.登入和註冊頁面的高度一致
2.切換登入和註冊頁面按鈕顏色，調整為Marche橘
![screencapture-localhost-3000-users-sign-in-2023-05-07-12_00_30](https://user-images.githubusercontent.com/130358340/236657099-fa04965b-871a-47e7-9d13-6c30dec438cf.png)

![screencapture-localhost-3000-users-sign-in-2023-05-07-12_02_06](https://user-images.githubusercontent.com/130358340/236657103-a9655b0c-af88-43ea-af74-f8ca24f5dab2.png)

<img width="1512" alt="截圖 2023-05-07 下午12 05 48" src="https://user-images.githubusercontent.com/130358340/236657104-ebdedca6-781c-4660-984d-0436f42f1ef8.png">

