### PR TITLE
Header新增至多個頁面、logo加上連結、商品項目加上連結、購物車簡單排版

### DIFF
--- a/app/controllers/carts_controller.rb
+++ b/app/controllers/carts_controller.rb
@@ -1,5 +1,6 @@
 class CartsController < ApplicationController
   before_action :authenticate_user!
+  before_action :set_q_ransack, only: [:index, :checkout]
   def index
     @cart = current_user.cart
     @cart_products = @cart.cart_products.includes(sale_info: [:product])
@@ -22,6 +23,10 @@ class CartsController < ApplicationController
 
   def cart_product_params
     params.require(:cart_product).permit(:quantity, :sale_info_id)
+  end
+
+  def set_q_ransack
+    @ransack_q = Product.ransack(params[:q])
   end
 
 end

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -1,5 +1,7 @@
 class ProductsController < ApplicationController
   before_action :set_product, only: [:show, :edit, :update, :destroy]
+  before_action :set_q_ransack, only: [:index, :show, :search, :category]
+  
   def index
     @products = Product.includes(:sale_infos).order(created_at: :desc)
     @ransack_q = Product.ransack(params[:q])
@@ -7,9 +9,6 @@ class ProductsController < ApplicationController
   end
 
   def show
-    # search
-    @ransack_q = Product.ransack(params[:q])
-
     # comment
     @product_comment = ProductComment.new
     if(params[:star].present?)
@@ -64,23 +63,23 @@ class ProductsController < ApplicationController
   end
 
   def search
-    @q = Product.ransack(params[:q])
-    @products = @q.result(distinct: true)
+    @products = @ransack_q.result(distinct: true)
   end
 
   def category
     @parent_category = Category.find(params[:id])
     @categories = @parent_category.children.includes(:products)
     @products = get_products_by_categories(@categories)
-    p '-'*30
-    p @products
-    p '-'*30
-    
   end
 
   private
+
   def set_product
     @product = Product.find(params[:id])
+  end
+
+  def set_q_ransack
+    @ransack_q = Product.ransack(params[:q])
   end
 
   def product_params
@@ -94,5 +93,6 @@ class ProductsController < ApplicationController
     end
     return products
   end
+
 end
 

--- a/app/views/carts/_item.html.erb
+++ b/app/views/carts/_item.html.erb
@@ -1,30 +1,34 @@
-<div class="container flex items-center justify-start w-11/12 m-2" data-controller="cart--item" data-cart-product-id="<%=cart_product.id%>" id="cart_product_<%=cart_product.id%>">
-  <%# checkbox %>
-  <%= check_box_tag "cart_product_ids[]", cart_product.id, false, id: "cart_product_#{cart_product.id}", class: "checkbox checkbox-sm rounded m-3" , data: {cart__item_target: "checkbox", cart__form_target: "checkbox", action: "change->cart--form#update"} %>
-  <%# 商品圖片 %>
-  <%= link_to root_path, class: "block w-20 h-20 m-3 bg-slate-300" do %>
-    <img src="https://picsum.photos/80/80/?random=12" class=''>
-  <% end %>
-  <h3 class="w-64"><%= cart_product.sale_info.product.name %></h3>
-  <%# 規格 %>
-  <div class="dropdown">
-    <label tabindex="0" class="m-1 spec-btn"><%= cart_product.sale_info.spec %></label>
-    <div tabindex="0" class="w-64 p-2 shadow dropdown-content card card-compact bg-primary text-primary-content">
-      <div class="card-body">test</div>
+<div class="flex" data-controller="cart--item" data-cart-product-id="<%=cart_product.id%>" id="cart_product_<%=cart_product.id%>">
+  <div class="flex items-center w-1/2 px-2">
+    <%# checkbox %>
+    <%= check_box_tag "cart_product_ids[]", cart_product.id, false, id: "cart_product_#{cart_product.id}", class: "checkbox checkbox-sm rounded p-2 m-2" , data: {cart__item_target: "checkbox", cart__form_target: "checkbox", action: "change->cart--form#update"} %>
+    <%# 商品圖片 %>
+    <%= link_to root_path, class: "block w-20 h-20 bg-slate-300 m-2" do %>
+      <img src="https://picsum.photos/80/80/?random=12" class=''>
+    <% end %>
+    <h3 class="p-2"><%= cart_product.sale_info.product.name %></h3>
+    <%# 規格 %>
+    <div class="ml-auto dropdown">
+      <label tabindex="0" class="m-1 spec-btn"><%= cart_product.sale_info.spec %></label>
+      <div tabindex="0" class="w-64 p-2 shadow dropdown-content card card-compact bg-primary text-primary-content">
+        <div class="card-body">test</div>
+      </div>
     </div>
   </div>
-  <%# 單價 %>
-  <div class="m-1">$<%= cart_product.sale_info.price %></div>
-  <%# 數量 %>
-  <div class="relative flex items-center m-2" data-cart--item-target="inputArea">
-    <button class="quantity-btn-left-arrow" data-action="click->cart--item#decrement click->cart--form#update">－</button>
-    <input type="number" class="quantity-btn-center-input" value="<%= cart_product.quantity %>" data-cart--item-target="quantity" data-action="change->cart--item#updateQuantity change->cart--form#update" data-storage="<%=cart_product.sale_info.storage%>">
-    <button class="quantity-btn-right-arrow" data-action="click->cart--item#increment click->cart--form#update">＋</button>
-    <p class="absolute hidden text-xs font-bold text-rose-400 left-1/4 top-full" data-cart--item-target="storageWarning">庫存：<%= cart_product.sale_info.storage %></p>
+  <div class="flex items-center w-1/2 px-2">
+    <%# 單價 %>
+    <div class="w-1/4 text-center">$<%= cart_product.sale_info.price %></div>
+    <%# 數量 %>
+    <div class="relative flex items-center justify-center w-1/4" data-cart--item-target="inputArea">
+      <button class="quantity-btn-left-arrow" data-action="click->cart--item#decrement click->cart--form#update">－</button>
+      <input type="number" class="quantity-btn-center-input" value="<%= cart_product.quantity %>" data-cart--item-target="quantity" data-action="change->cart--item#updateQuantity change->cart--form#update" data-storage="<%=cart_product.sale_info.storage%>">
+      <button class="quantity-btn-right-arrow" data-action="click->cart--item#increment click->cart--form#update">＋</button>
+      <p class="absolute hidden text-xs font-bold text-rose-400 left-1/4 top-full" data-cart--item-target="storageWarning">庫存：<%= cart_product.sale_info.storage %></p>
+    </div>
+    <%# 總價 ＝ 單價 x 數量 %>
+    <div class="flex items-center justify-center w-1/4 m-2 text-center text-amber-500" data-cart--item-target="itemTotalPrice" data-unit-price="<%= cart_product.sale_info.price %>" data-cart--form-target="itemTotalPrice">$?</div>
+    <%= link_to cart_destroy_path(cart_product.id), method: :delete, data: {confirm: "確定要刪除該商品？"}, class: "w-1/4 text-center" do %>
+      <i class="p-1 m-1 text-red-500 rounded bg-neutral-100 drop-shadow fa-regular fa-trash-can"></i>
+    <% end %>
   </div>
-  <%# 總價 ＝ 單價 x 數量 %>
-  <div class="flex items-center justify-end w-20 m-2 text-amber-500" data-cart--item-target="itemTotalPrice" data-unit-price="<%= cart_product.sale_info.price %>" data-cart--form-target="itemTotalPrice">$?</div>
-  <%= link_to cart_destroy_path(cart_product.id), method: :delete, data: {confirm: "確定要刪除該商品？"} do %>
-    <i class="p-1 m-1 text-red-500 rounded bg-neutral-100 drop-shadow fa-regular fa-trash-can"></i>
-  <% end %>
 </div>

--- a/app/views/carts/_item.html.erb
+++ b/app/views/carts/_item.html.erb
@@ -2,9 +2,9 @@
   <%# checkbox %>
   <%= check_box_tag "cart_product_ids[]", cart_product.id, false, id: "cart_product_#{cart_product.id}", class: "checkbox checkbox-sm rounded m-3" , data: {cart__item_target: "checkbox", cart__form_target: "checkbox", action: "change->cart--form#update"} %>
   <%# 商品圖片 %>
-  <div class="w-20 h-20 m-3 bg-slate-300">
+  <%= link_to root_path, class: "block w-20 h-20 m-3 bg-slate-300" do %>
     <img src="https://picsum.photos/80/80/?random=12" class=''>
-  </div>
+  <% end %>
   <h3 class="w-64"><%= cart_product.sale_info.product.name %></h3>
   <%# 規格 %>
   <div class="dropdown">

--- a/app/views/carts/_item.html.erb
+++ b/app/views/carts/_item.html.erb
@@ -3,7 +3,7 @@
     <%# checkbox %>
     <%= check_box_tag "cart_product_ids[]", cart_product.id, false, id: "cart_product_#{cart_product.id}", class: "checkbox checkbox-sm rounded p-2 m-2" , data: {cart__item_target: "checkbox", cart__form_target: "checkbox", action: "change->cart--form#update"} %>
     <%# 商品圖片 %>
-    <%= link_to root_path, class: "block w-20 h-20 bg-slate-300 m-2" do %>
+    <%= link_to product_path(cart_product.sale_info.product_id), class: "block w-20 h-20 bg-slate-300 m-2" do %>
       <img src="https://picsum.photos/80/80/?random=12" class=''>
     <% end %>
     <h3 class="p-2"><%= cart_product.sale_info.product.name %></h3>

--- a/app/views/carts/checkout.html.erb
+++ b/app/views/carts/checkout.html.erb
@@ -1,3 +1,4 @@
+<%= render partial: 'layouts/page_header', locals: {ransack_q: @ransack_q} %>
 <h1>臨時的結帳頁面 Checkout</h1>
 <p>商品數量：<%= @cart_products.count %></p>
 <% @cart_products.each do |c| %>
@@ -7,11 +8,9 @@
     <span class="bg-sky-100">數量：<%= c.quantity %></span>
   </div>
 <% end %>
-
 <%= form_with url: orders_path, method: :post do |form| %>
   <% @cart_products.each do |c|%>
-  <%= hidden_field_tag "cart_product[]", value = c.id %>
-<% end %>
-
+    <%= hidden_field_tag "cart_product[]", value = c.id %>
+  <% end %>
   <%= form.submit "產生訂單" %>
 <% end %>

--- a/app/views/carts/index.html.erb
+++ b/app/views/carts/index.html.erb
@@ -1,4 +1,4 @@
-<%# <div class="container w-full mx-auto"> %>
+<%= render partial: 'layouts/page_header', locals: {ransack_q: @ransack_q} %>
 <section class="container w-11/12 m-auto border bg-gay-200">
   <%= form_with url: checkout_path, method: :get, data: { turbo: "false", controller: "cart--form" } do |form| %>
     <div class="flex items-center justify-start bg-gray-100 h-14">

--- a/app/views/carts/index.html.erb
+++ b/app/views/carts/index.html.erb
@@ -1,17 +1,19 @@
 <%= render partial: 'layouts/page_header', locals: {ransack_q: @ransack_q} %>
-<section class="container w-11/12 m-auto border bg-gay-200">
+<section class="container mx-auto mt-6 border bg-gay-200">
   <%= form_with url: checkout_path, method: :get, data: { turbo: "false", controller: "cart--form" } do |form| %>
     <div class="flex items-center justify-start bg-gray-100 h-14">
-      <p class="m-2 text-sm w-96">商品</p>
-      <p class="mr-2 text-sm text-center w-28">單價</p>
-      <p class="w-40 mr-2 text-sm text-center">數量</p>
-      <p class="mr-2 text-sm text-center w-28">總計</p>
-      <p class="mr-6 text-sm text-center w-28">操作</p>
+      <p class="w-1/2 text-sm text-center">商品</p>
+      <div class="flex w-1/2 ">
+        <p class="w-1/4 text-sm text-center">單價</p>
+        <p class="w-1/4 text-sm text-center">數量</p>
+        <p class="w-1/4 text-sm text-center">總計</p>
+        <p class="w-1/4 text-sm text-center">操作</p>
+      </div>
     </div>
     <%= render partial:'carts/item', collection: @cart_products , as: :cart_product%>
     <div class="container flex items-center h-20 bg-gray-100">
       <input type="checkbox"  
-        class="ml-6 mr-4 checkbox checkbox-primary" data-action="change->cart--form#checkAllBox"/>
+        class="ml-6 mr-4 border-black checkbox checkbox-primary" data-action="change->cart--form#checkAllBox"/>
       <p class="mr-8 text-sm w-96">全選 (<%= @cart_products.count %>)</p>
       <p class="mr-3 text-sm w-fit ms-auto">總金額 (<span data-cart--form-target="productNum">0</span> 個商品) :<span class="m-2 text-lg font-semibold text-orange-600" data-cart--form-target="totalPrice">$0</span></p>
       <%= form.submit "去買單", class: "bg-orange-500 hover:bg-orange-600 hover:cursor-pointer p-2 m-2 rounded text-white text-sm w-28"%>

--- a/app/views/layouts/_page_header.html.erb
+++ b/app/views/layouts/_page_header.html.erb
@@ -1,0 +1,16 @@
+<header class="flex items-center justify-between w-full px-6 pb-3 bg-marche_orange 2xl:px-[136px] xl:px-32 lg:px-[116px] md:px-28 sm:px-14 h-14">
+  <section class="w-0 mb-1 mr-2 link link-hover md:min-w-fit">
+    <%= link_to root_path do%>
+      <%= image_tag "marche_logo_home.svg" ,class: "h-12 mb-1" %>
+    <% end %>
+  </section>
+  <div class="self-center mt-1 mb-2 sm:mr-6 md:mr-10 lg:mr-12 xl:mr-16">
+    <%= search_form_for ransack_q, url: search_path, class: "flex", data: {turbo: "false"} do |form|%>
+      <%= form.search_field :name_cont, class: "w-60 2xl:w-[800px] xl:w-[640px] lg:w-[420px] md:w-68 sm:w-56 rounded-lg" %>
+      <%= button_tag type: 'submit', class: "ml-2 fill-marche_white" do %>
+        <%= raw('<svg xmlns="http://www.w3.org/2000/svg" width="28" height="28" viewBox="0 0 48 48" id="search"><path d="M46.599 40.236L36.054 29.691C37.89 26.718 39 23.25 39 19.5 39 8.73 30.27 0 19.5 0S0 8.73 0 19.5 8.73 39 19.5 39c3.75 0 7.218-1.11 10.188-2.943l10.548 10.545a4.501 4.501 0 0 0 6.363-6.366zM19.5 33C12.045 33 6 26.955 6 19.5S12.045 6 19.5 6 33 12.045 33 19.5 26.955 33 19.5 33z"></path></svg>') %>
+      <% end %>
+    <% end %>
+  </div>
+  <%= link_to(raw('<svg xmlns="http://www.w3.org/2000/svg" width="34" height="34" viewBox="0 0 24 24" class="mt-3 mr-3"><path d="M21.5,15a3,3,0,0,0-1.9-2.78l1.87-7a1,1,0,0,0-.18-.87A1,1,0,0,0,20.5,4H6.8L6.47,2.74A1,1,0,0,0,5.5,2h-2V4H4.73l2.48,9.26a1,1,0,0,0,1,.74H18.5a1,1,0,0,1,0,2H5.5a1,1,0,0,0,0,2H6.68a3,3,0,1,0,5.64,0h2.36a3,3,0,1,0,5.82,1,2.94,2.94,0,0,0-.4-1.47A3,3,0,0,0,21.5,15Zm-3.91-3H9L7.34,6H19.2ZM9.5,20a1,1,0,1,1,1-1A1,1,0,0,1,9.5,20Zm8,0a1,1,0,1,1,1-1A1,1,0,0,1,17.5,20Z"></path></svg>'), cart_path, class: "fill-marche_white mb-4 ml-3") %>
+</header>

--- a/app/views/products/_category.html.erb
+++ b/app/views/products/_category.html.erb
@@ -1,6 +1,6 @@
 <li class="w-1/12 p-2 border grow hover:shadow-lg">
   <%= link_to product_category_path(category.id) do%>
-    <div class="">
+    <div class="mx-auto">
       <img src="https://picsum.photos/80/80/?random=20" class="rounded-full">
     </div>
     <p class="my-1 text-xs text-center text-gray-500"><%= category.content %></p>

--- a/app/views/products/category.html.erb
+++ b/app/views/products/category.html.erb
@@ -1,3 +1,4 @@
+<%= render partial: 'layouts/page_header', locals: {ransack_q: @ransack_q} %>
 <h1 class="self-end w-10/12 mx-auto mt-8 mb-1 text-xl font-bold text-marche_black">分類：<%= @parent_category.content%></h1>
 <div class="grid w-10/12 gap-4 mx-auto sm:grid-cols-3 lg:grid-cols-5 md:grid-cols-4 xl:grid-cols-6">
   <%= render partial:'product',collection: @products, as: :product %>

--- a/app/views/products/index.html.erb
+++ b/app/views/products/index.html.erb
@@ -1,17 +1,4 @@
-<header class="flex items-center justify-between w-full px-6 pb-3 bg-marche_orange 2xl:px-[136px] xl:px-32 lg:px-[116px] md:px-28 sm:px-14 h-14">
-  <section class="w-0 mb-1 mr-2 link link-hover md:min-w-fit">
-    <%= image_tag "marche_logo_home.svg" ,class: "h-12 mb-1" %>
-  </section>
-  <div class="self-center mt-1 mb-2 sm:mr-6 md:mr-10 lg:mr-12 xl:mr-16">
-    <%= search_form_for @ransack_q, url: search_path, class: "flex", data: {turbo: "false"} do |form|%>
-      <%= form.search_field :name_cont, class: "w-60 2xl:w-[800px] xl:w-[640px] lg:w-[420px] md:w-68 sm:w-56 rounded-lg" %>
-      <%= button_tag type: 'submit', class: "ml-2 fill-marche_white" do %>
-        <%= raw('<svg xmlns="http://www.w3.org/2000/svg" width="28" height="28" viewBox="0 0 48 48" id="search"><path d="M46.599 40.236L36.054 29.691C37.89 26.718 39 23.25 39 19.5 39 8.73 30.27 0 19.5 0S0 8.73 0 19.5 8.73 39 19.5 39c3.75 0 7.218-1.11 10.188-2.943l10.548 10.545a4.501 4.501 0 0 0 6.363-6.366zM19.5 33C12.045 33 6 26.955 6 19.5S12.045 6 19.5 6 33 12.045 33 19.5 26.955 33 19.5 33z"></path></svg>') %>
-      <% end %>
-    <% end %>
-  </div>
-  <%= link_to(raw('<svg xmlns="http://www.w3.org/2000/svg" width="34" height="34" viewBox="0 0 24 24" class="mt-3 mr-3"><path d="M21.5,15a3,3,0,0,0-1.9-2.78l1.87-7a1,1,0,0,0-.18-.87A1,1,0,0,0,20.5,4H6.8L6.47,2.74A1,1,0,0,0,5.5,2h-2V4H4.73l2.48,9.26a1,1,0,0,0,1,.74H18.5a1,1,0,0,1,0,2H5.5a1,1,0,0,0,0,2H6.68a3,3,0,1,0,5.64,0h2.36a3,3,0,1,0,5.82,1,2.94,2.94,0,0,0-.4-1.47A3,3,0,0,0,21.5,15Zm-3.91-3H9L7.34,6H19.2ZM9.5,20a1,1,0,1,1,1-1A1,1,0,0,1,9.5,20Zm8,0a1,1,0,1,1,1-1A1,1,0,0,1,17.5,20Z"></path></svg>'), cart_path, class: "fill-marche_white mb-4 ml-3") %>
-</header>
+<%= render partial: 'layouts/page_header', locals: {ransack_q: @ransack_q} %>
 <%= render 'shared/flash' if flash.any? %>
 <%# Banner%>
 <div class="container w-10/12 mx-auto my-10">

--- a/app/views/products/search.html.erb
+++ b/app/views/products/search.html.erb
@@ -1,3 +1,4 @@
+<%= render partial: 'layouts/page_header', locals: {ransack_q: @ransack_q} %>
 <h1 class="self-end w-10/12 mx-auto mt-8 mb-1 text-xl font-bold text-marche_orange"><%= params[:keyword]%> 搜尋結果 </h1>
 <div class="grid w-10/12 gap-4 mx-auto sm:grid-cols-3 lg:grid-cols-5 md:grid-cols-4 xl:grid-cols-6">
   <%= render  @products %>

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -1,17 +1,4 @@
-<header class="flex items-center justify-between w-full px-6 pb-3 bg-marche_orange 2xl:px-[136px] xl:px-32 lg:px-[116px] md:px-28 sm:px-14 h-14">
-  <section class="w-0 mb-1 mr-2 link link-hover md:min-w-fit">
-    <%= image_tag "marche_logo_home.svg" ,class: "h-12 mb-1" %>
-  </section>
-  <div class="self-center mt-1 mb-2 sm:mr-6 md:mr-10 lg:mr-12 xl:mr-16">
-    <%= search_form_for @ransack_q, url: search_path, class: "flex", data: {turbo: "false"} do |form|%>
-      <%= form.search_field :name_cont, class: "w-60 2xl:w-[800px] xl:w-[640px] lg:w-[420px] md:w-68 sm:w-56 rounded-lg" %>
-      <%= button_tag type: 'submit', class: "ml-2 fill-marche_white" do %>
-        <%= raw('<svg xmlns="http://www.w3.org/2000/svg" width="28" height="28" viewBox="0 0 48 48" id="search"><path d="M46.599 40.236L36.054 29.691C37.89 26.718 39 23.25 39 19.5 39 8.73 30.27 0 19.5 0S0 8.73 0 19.5 8.73 39 19.5 39c3.75 0 7.218-1.11 10.188-2.943l10.548 10.545a4.501 4.501 0 0 0 6.363-6.366zM19.5 33C12.045 33 6 26.955 6 19.5S12.045 6 19.5 6 33 12.045 33 19.5 26.955 33 19.5 33z"></path></svg>') %>
-      <% end %>
-    <% end %>
-  </div>
-  <%= link_to(raw('<svg xmlns="http://www.w3.org/2000/svg" width="34" height="34" viewBox="0 0 24 24" class="mt-3 mr-3"><path d="M21.5,15a3,3,0,0,0-1.9-2.78l1.87-7a1,1,0,0,0-.18-.87A1,1,0,0,0,20.5,4H6.8L6.47,2.74A1,1,0,0,0,5.5,2h-2V4H4.73l2.48,9.26a1,1,0,0,0,1,.74H18.5a1,1,0,0,1,0,2H5.5a1,1,0,0,0,0,2H6.68a3,3,0,1,0,5.64,0h2.36a3,3,0,1,0,5.82,1,2.94,2.94,0,0,0-.4-1.47A3,3,0,0,0,21.5,15Zm-3.91-3H9L7.34,6H19.2ZM9.5,20a1,1,0,1,1,1-1A1,1,0,0,1,9.5,20Zm8,0a1,1,0,1,1,1-1A1,1,0,0,1,17.5,20Z"></path></svg>'), cart_path, class: "fill-marche_white mb-4 ml-3") %>
-</header>
+<%= render partial: 'layouts/page_header', locals: {ransack_q: @ransack_q} %>
 <div class="flex w-full max-w-2xl mx-auto">
   <div class="w-full mx-auto">
     <%= render 'shared/flash' if flash.any? %>


### PR DESCRIPTION
將搜尋欄位的header抽出成_page_header.html.erb以增加復用性，多個頁面新增header，其對應的controller也有修改。
購物車簡單網格系統排版。
<img width="1440" alt="截圖 2023-05-08 上午1 44 44" src="https://user-images.githubusercontent.com/71165941/236693802-438ba35d-606a-44fb-864a-0920c55d3fe9.png">

商品項目加上該產品的show頁面超連結，header的logo加上首頁超連結。