### PR TITLE
修復購物車總價計算錯誤、整理購物車stimulus程式碼

### DIFF
--- a/app/javascript/controllers/cart/application.js
+++ b/app/javascript/controllers/cart/application.js
@@ -1,0 +1,14 @@
+// format price to money
+export function formatMoney(price) {
+  let integerPart = price.toString().split(".")[0].split("").reverse();
+  for (let i = 3; i < integerPart.length; i += 4) {
+    integerPart.splice(i, 0, ",");
+  }
+  let decimalPart = price.toString().split(".")[1];
+  decimalPart = decimalPart == undefined ? "" : `.${decimalPart}`;
+  return `$${integerPart.reverse().join("")}${decimalPart}`;
+}
+// 金額字串轉換成純數字 $123,456.78 => 123456.78
+export function convertMoneyToNumber(price) {
+  return Number(price.split("$")[1].split(",").join(""));
+}

--- a/app/javascript/controllers/cart/form_controller.js
+++ b/app/javascript/controllers/cart/form_controller.js
@@ -1,4 +1,5 @@
 import {Controller} from "@hotwired/stimulus";
+import {formatMoney, convertMoneyToNumber} from "./application";
 
 // Connects to data-controller="cart--form"
 export default class extends Controller {
@@ -14,33 +15,21 @@ export default class extends Controller {
   update() {
     let sum = 0;
     let checkedNum = 0;
-    for (let i = 0; i < this.checkboxTargets.length; i++) {
-      if (this.checkboxTargets[i].checked) {
-        sum += this.convertMoneyToNumber(
-          this.itemTotalPriceTargets[i].textContent
-        );
-        checkedNum += 1;
-      }
-    }
-    this.totalPriceTarget.textContent = this.formatMoney(sum);
-    this.productNumTarget.textContent = checkedNum;
-  }
-  boxChecked() {}
-  totalPriceChanged() {}
-  convertMoneyToNumber(price) {
-    return Number(price.split("$")[1].split(",").join(""));
+    setTimeout(() => {
+      this.checkboxTargets.forEach((element, index) => {
+        if (element.checked) {
+          sum += convertMoneyToNumber(
+            this.itemTotalPriceTargets[index].textContent
+          );
+          checkedNum += 1;
+        }
+      });
+      this.totalPriceTarget.textContent = formatMoney(sum);
+      this.productNumTarget.textContent = checkedNum;
+    }, 101);
   }
   preventSubmit(e) {
     e.preventDefault();
-  }
-  formatMoney(price) {
-    let integerPart = price.toString().split(".")[0].split("").reverse();
-    for (let i = 3; i < integerPart.length; i += 4) {
-      integerPart.splice(i, 0, ",");
-    }
-    let decimalPart = price.toString().split(".")[1];
-    decimalPart = decimalPart == undefined ? "" : `.${decimalPart}`;
-    return `$${integerPart.reverse().join("")}${decimalPart}`;
   }
   checkAllBox() {
     if (this.isAllChecked) {

--- a/app/javascript/controllers/cart/item_controller.js
+++ b/app/javascript/controllers/cart/item_controller.js
@@ -1,5 +1,6 @@
 import {Controller} from "@hotwired/stimulus";
 import {post} from "@rails/request.js";
+import {formatMoney} from "./application";
 
 // Connects to data-controller="cart--item"
 export default class extends Controller {
@@ -71,17 +72,7 @@ export default class extends Controller {
   updateItemTotalPrice() {
     let itemPrice =
       Number(this.itemTotalPriceTarget.dataset.unitPrice) * this.quantityNum;
-    this.itemTotalPriceTarget.textContent = this.formatMoney(itemPrice);
-  }
-  // format price to money
-  formatMoney(price) {
-    let integerPart = price.toString().split(".")[0].split("").reverse();
-    for (let i = 3; i < integerPart.length; i += 4) {
-      integerPart.splice(i, 0, ",");
-    }
-    let decimalPart = price.toString().split(".")[1];
-    decimalPart = decimalPart == undefined ? "" : `.${decimalPart}`;
-    return `$${integerPart.reverse().join("")}${decimalPart}`;
+    this.itemTotalPriceTarget.textContent = formatMoney(itemPrice);
   }
   // set quantityTarget
   setQuantityTarget() {
@@ -97,10 +88,10 @@ export default class extends Controller {
     if (this.quantityNum == this.storageNum) {
       this.revealStorageWarning();
     } else {
-      this.hiddenStorageWarning();
+      this.hideStorageWarning();
     }
   }
-  hiddenStorageWarning() {
+  hideStorageWarning() {
     this.storageWarningTarget.classList.add("hidden");
   }
   revealStorageWarning() {


### PR DESCRIPTION
購物車總價計算會因為顯示上的延遲而導致計算結果錯誤，現在設定等待101ms後再執行計算，以此解決此bug。

購物車部分重複程式碼抽出來成單一檔案，簡化原先的寫法。