### PR TITLE
Update show&checkout pages

### DIFF
--- a/app/controllers/carts_controller.rb
+++ b/app/controllers/carts_controller.rb
@@ -13,6 +13,12 @@ class CartsController < ApplicationController
     @cart = current_user.cart
     @cart_products =  @cart.cart_products.includes(sale_info: [:product]).where(id: params[:cart_product_ids])
     @order = Order.new
+    @total_price = params[:total_price_checkout]
+
+    p '-'*40
+    p params
+    p @total_price
+    p '-'*40
   end
 
   def destroy

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -6,6 +6,7 @@ class OrdersController < ApplicationController
     @cart_products = CartProduct.where(id: params[:cart_product]).includes(:sale_info)
 
     total_price = 0
+    total_price.floor
     @cart_products.each do |c|
       # 算總價
       total_price += c.quantity * c.sale_info.price

--- a/app/javascript/controllers/cart/form_controller.js
+++ b/app/javascript/controllers/cart/form_controller.js
@@ -5,13 +5,7 @@ import {post, destroy} from "@rails/request.js";
 
 // Connects to data-controller="cart--form"
 export default class extends Controller {
-  static targets = [
-    "checkbox",
-    "itemTotalPrice",
-    "totalPrice",
-    "productNum",
-    "cartItem",
-  ];
+  static targets = ["checkbox", "itemTotalPrice", "totalPrice", "productNum", "totalPriceCheckout"];
   connect() {
     // form表單預設會找尋第一個submit or button進行click事件，因此要preventDefault
     this.element.setAttribute(
@@ -19,6 +13,7 @@ export default class extends Controller {
       "keydown.enter->cart--form#preventSubmit"
     );
     this.isAllChecked = false;
+    console.log(this.totalPriceCheckoutTarget)
   }
   update() {
     let sum = 0;
@@ -34,6 +29,7 @@ export default class extends Controller {
       });
       this.totalPriceTarget.textContent = formatMoney(sum);
       this.productNumTarget.textContent = checkedNum;
+      this.totalPriceCheckoutTarget.setAttribute("value", formatMoney(sum))
     }, 101);
   }
   preventSubmit(e) {

--- a/app/views/carts/checkout.html.erb
+++ b/app/views/carts/checkout.html.erb
@@ -1,6 +1,6 @@
 <%= render partial: 'layouts/page_header', locals: {ransack_q: @ransack_q} %>
-<section class="w-10/12 mx-auto min-h-[50vh] mt-20">  
-  <div class="flex justify-center mt-5 mb-5">
+<section class="w-10/12 mx-auto mt-1 0">  
+  <div class="flex justify-center mt-10 mb-5">
     <h1 class="text-2xl">結帳頁面</h1>
   </div>
   <div class="m-3">
@@ -8,7 +8,7 @@
   </div>
 
   <table class="border-2 text-center w-full mx-auto">
-    <tr class="border-b">
+    <tr class="border-b bg-gray-100">
       <td class="text-lg w-3/12 border-r-2">產品名稱</td>
       <td class="text-lg w-7/12">商品規格</td>
       <td class="text-lg w-2/12 border-l-2">數量</td>
@@ -16,7 +16,7 @@
 
     <% @cart_products.each do |c| %>
       <tr class="border"> 
-        <td class="py-2"><%= c.sale_info.product.name %></td>
+        <td class="py-3"><%= c.sale_info.product.name %></td>
         <td><%= c.sale_info.spec %></td>
         <td><%= c.quantity %></td>
       </tr>
@@ -29,32 +29,34 @@
     <% end %>
 
     <%# 這段要讓使用者填寫收件人資訊 %>
-    <div class="flex justify-center text-2xl m-4">
-      <p>請填寫收件人資訊</p>
-    </div>
-
-    <div class="flex justify-around mt-8 mb-4">
-      <div>
-        <%= form.label :receiver, "收件人" %>
-        <%= form.text_field :receiver %>
+    <div class="border-2 mt-8">
+      <div class="flex justify-center text-2xl m-4">
+        <p>請填寫收件人資訊</p>
       </div>
-      <div>
-        <%= form.label :shipping_address, "配送地址" %>
-        <%= form.text_field :shipping_address %>
+      <div class="flex justify-around mt-8 mb-4">
+        <div>
+          <%= form.label :receiver, "收件人" %>
+          <%= form.text_field :receiver %>
+        </div>
+        <div>
+          <%= form.label :shipping_address, "配送地址" %>
+          <%= form.text_field :shipping_address %>
+        </div>
+        <div>
+          <%= form.label :shipping_status, "配送方式" %>
+          <%= form.text_field :shipping_status %>
+        </div>
+        <div>
+          <%= form.label :note, "備註" %>
+          <%= form.text_field :note %>
+        </div>
       </div>
-      <div>
-        <%= form.label :shipping_status, "配送方式" %>
-        <%= form.text_field :shipping_status %>
-      </div>
-      <div>
-        <%= form.label :note, "備註" %>
-        <%= form.text_field :note %>
-      </div>
-    </div>
-
-    <div class="flex justify-end mr-2 mt-1 ml-2">
-      <%= link_to "上一頁", :back, class: "border text-green-500 bg-green-50 hover:cursor-pointer p-2 m-2 rounded hover:bg-green-100" %>
-      <%= form.submit "產生訂單", class: "border text-green-500 bg-green-50 hover:cursor-pointer p-2 m-2 rounded hover:bg-green-100" %>
+    </div>  
+ 
+    <div class="flex justify-end items-center mt-8 pl-2 pr-2 bg-gray-100">
+      <%= link_to "上一頁", :back, class: "mr-auto border text-green-500 bg-green-50 hover:cursor-pointer p-2 m-2 rounded hover:bg-green-100" %>
+      <p class="mr-6 text-lg text-red-600">本次結帳金額為 <%= @total_price %> </p>
+      <%= form.submit "金額確認，產生訂單", class: "border text-green-500 bg-green-50 hover:cursor-pointer p-2 m-2 rounded hover:bg-green-100" %>
     </div>
   <% end %>
 </section>

--- a/app/views/carts/index.html.erb
+++ b/app/views/carts/index.html.erb
@@ -1,6 +1,7 @@
 <%= render partial: 'layouts/page_header', locals: {ransack_q: @ransack_q} %>
 <section class="container mx-auto mt-6 border bg-gay-200">
   <%= form_with url: checkout_path, method: :get, data: { turbo: "false", controller: "cart--form", cart_id: current_user.cart.id} do |form| %>
+    <%= hidden_field_tag "total_price_checkout", value = "", data: {cart__form_target: "totalPriceCheckout"} %>
     <div class="flex items-center justify-start bg-gray-100 h-14">
       <p class="w-1/2 text-sm text-center">商品</p>
       <div class="flex w-1/2 ">

--- a/app/views/orders/show.html.erb
+++ b/app/views/orders/show.html.erb
@@ -2,7 +2,7 @@
 <%= render 'shared/flash' if flash.any? %>
 <section class="w-8/12 mx-auto mt-20">
   <div class="border-2">
-    <div class="flex justify-center border-b-2">
+    <div class="flex justify-center border-b-2 bg-gray-100">
       <h1 class="text-xl m-2">訂單資訊</h1>
     </div>
     

--- a/app/views/orders/show.html.erb
+++ b/app/views/orders/show.html.erb
@@ -1,53 +1,59 @@
 <%# render partial: 'layouts/page_header', locals: {ransack_q: @ransack_q} %>
 <%= render 'shared/flash' if flash.any? %>
-<section class="w-8/12 mx-auto min-h-[50vh] mt-20 border-2">
-  <div class="flex justify-center border-b-2">
-    <h1 class="text-xl m-2">這是你的訂單</h1>
-  </div>
-  
-  <div class="flex justify-around px-3 pt-2">
-    <p class="w-1/2 text-center text-lg">訂單編號</p>
-    <p class="w-1/2 text-center text-lg break-words"><%= @order.tracking_number %></p>
-  </div>
-  <div class="flex justify-around px-3 pt-2">
-    <p class="w-1/2 text-center text-lg">總價</p> 
-    <p class="w-1/2 text-center text-lg"><%= @order.total_price %></p>
-  </div>
-  <div class="flex justify-around px-3 pt-2">
-    <p class="w-1/2 text-center text-lg">付款狀態</p>
-    <p class="w-1/2 text-center text-lg"><%= @order.payment_status %></p>
-  </div>
-  <div class="flex justify-around px-3 pt-2">
-    <p class="w-1/2 text-center text-lg">付款方式</p>
-    <p class="w-1/2 text-center text-lg"><%= @order.payment_method %></p>
-  </div>
+<section class="w-8/12 mx-auto mt-20">
+  <div class="border-2">
+    <div class="flex justify-center border-b-2">
+      <h1 class="text-xl m-2">訂單資訊</h1>
+    </div>
+    
+    <div class="flex justify-around px-3 pt-2">
+      <p class="w-1/2 text-center text-lg">訂單編號</p>
+      <p class="w-1/2 text-center text-lg break-words"><%= @order.tracking_number %></p>
+    </div>
+    <div class="flex justify-around px-3 pt-2">
+      <p class="w-1/2 text-center text-lg">付款狀態</p>
+      <p class="w-1/2 text-center text-lg"><%= @order.payment_status %></p>
+    </div>
+    <div class="flex justify-around px-3 pt-2">
+      <p class="w-1/2 text-center text-lg">付款方式</p>
+      <p class="w-1/2 text-center text-lg">信用卡付費</p>
+    </div>
+    <div class="flex justify-around px-3 pt-2">
+      <p class="w-1/2 text-center text-xl text-red-600">總金額</p> 
+      <p class="w-1/2 text-center text-xl text-red-600"><%= number_with_delimiter(@order.total_price.floor, delimiter: ',') %></p>
+    </div>
+    <%# 分隔線 %>
+    <div class="flex justify-center m-3">
+      <div class="border-b w-4/5"></div>
+    </div>
 
-  <% if @order.payment_status == "pending"%>
-  <%# 這段是要送給藍新的資訊%>
-    <%= form_with(url: 'https://ccore.newebpay.com/MPG/mpg_gateway', method: "post") do |form| %>
-      <input type="hidden" id="MerchantID" name="MerchantID" value="<%= @form_info[:MerchantID] %>">
-      <input type="hidden" id="TradeInfo" name="TradeInfo" value="<%= @form_info[:TradeInfo] %>">
-      <input type="hidden" id="TradeSha" name="TradeSha" value="<%= @form_info[:TradeSha] %>">
-      <input type="hidden" id="Version" name="Version" value="<%= @form_info[:Version] %>">
-        
-      <%# 客戶資訊 %>
-      <div class="flex justify-around px-3 pt-2">
-        <p class="w-1/2 text-center text-lg">收件人</p>
-        <p class="w-1/2 text-center text-lg"><%= @order.receiver %></p>
-      </div>
-      <div class="flex justify-around px-3 pt-2">
-        <p class="w-1/2 text-center text-lg">配送地址</p>
-        <p class="w-1/2 text-center text-lg"><%= @order.shipping_address %></p>
-      </div>
-      <div class="flex justify-around px-3 p-2">
-        <p class="w-1/2 text-center text-lg">配送方式</p>
-        <p class="w-1/2 text-center text-lg"><%= @order.shipping_status %></p>
-      </div>
-      <div class="flex justify-around px-3 p-2">
-        <p class="w-1/2 text-center text-lg">備註</p>
-        <p class="w-1/2 text-center text-lg"><%= @order.note %></p>
-      </div>
-        
+    <% if @order.payment_status == "pending"%>
+    <%# 這段是要送給藍新的資訊%>
+      <%= form_with(url: 'https://ccore.newebpay.com/MPG/mpg_gateway', method: "post") do |form| %>
+        <input type="hidden" id="MerchantID" name="MerchantID" value="<%= @form_info[:MerchantID] %>">
+        <input type="hidden" id="TradeInfo" name="TradeInfo" value="<%= @form_info[:TradeInfo] %>">
+        <input type="hidden" id="TradeSha" name="TradeSha" value="<%= @form_info[:TradeSha] %>">
+        <input type="hidden" id="Version" name="Version" value="<%= @form_info[:Version] %>">
+          
+        <%# 客戶資訊 %>
+        <div class="flex justify-around px-3 pt-2">
+          <p class="w-1/2 text-center text-lg">收件人</p>
+          <p class="w-1/2 text-center text-lg"><%= @order.receiver %></p>
+        </div>
+        <div class="flex justify-around px-3 pt-2">
+          <p class="w-1/2 text-center text-lg">配送地址</p>
+          <p class="w-1/2 text-center text-lg"><%= @order.shipping_address %></p>
+        </div>
+        <div class="flex justify-around px-3 p-2">
+          <p class="w-1/2 text-center text-lg">配送方式</p>
+          <p class="w-1/2 text-center text-lg"><%= @order.shipping_status %></p>
+        </div>
+        <div class="flex justify-around px-3 p-2">
+          <p class="w-1/2 text-center text-lg">備註</p>
+          <p class="w-1/2 text-center text-lg"><%= @order.note %></p>
+        </div>
+  </div>
+    
       <div class="flex justify-around">
         <div class="w-1/2 flex items-center justify-around px-3 p-2">
           <%= link_to "上一頁", :back, class: "border text-green-500 bg-green-50 hover:cursor-pointer p-2 m-2 rounded hover:bg-green-100" %>


### PR DESCRIPTION
在checkout頁面付款按鈕旁新增了總金額
<img width="1440" alt="截圖 2023-05-10 下午5 08 49" src="https://github.com/5xRuby13thMarche/Marche/assets/127717275/8cea47fd-e5f3-45f8-8c37-5d70d6c68447">
在show頁面的title新增了背景色，並做了一些微調
<img width="1440" alt="截圖 2023-05-10 下午5 08 57" src="https://github.com/5xRuby13thMarche/Marche/assets/127717275/eebb220b-905e-4884-9eea-b422184c3eb3">
藍新傳回來的show頁面也做了排版上的優化
<img width="1440" alt="截圖 2023-05-10 下午5 08 25" src="https://github.com/5xRuby13thMarche/Marche/assets/127717275/8a19ff2e-fb29-4739-a08a-187043e82286">

