### PR TITLE
首頁商品呈現區塊修改，輪播左右按鈕位置樣式調整

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -13,3 +13,25 @@
  *= require_tree .
  *= require_self
  */
+
+.slick-prev {
+    left: 10px !important;
+    width: 40px !important;
+    height: 40px !important;
+    z-index: 1;
+  }
+
+.slick-prev:before {
+    font-size: 40px !important;
+  }
+   
+.slick-next {
+    right: 10px !important;
+    width: 40px !important;
+    height: 40px !important;
+    z-index: 1;
+  }
+
+.slick-next:before {
+    font-size: 40px !important;
+  }

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -32,5 +32,38 @@
         arrows: true,
       });
     </script>
+    <%# 熱門商品&最新商品 JQuery%>
+    <script>
+      $('.slider_hot').slick({
+        infinite: false,
+        slidesToShow: 6,
+        slidesToScroll: 6,
+        speed: 700,
+        arrows: true,
+        responsive: [
+          {
+            breakpoint: 1280,
+            settings: {
+              slidesToShow: 5,
+              slidesToScroll: 5
+            }
+          },
+          {
+            breakpoint: 1024,
+            settings: {
+              slidesToShow: 4,
+              slidesToScroll: 4
+            }
+          },
+          {
+            breakpoint: 768,
+            settings: {
+              slidesToShow: 3,
+              slidesToScroll: 3
+            }
+          },
+        ]
+      });
+    </script>
   </body>
 </html>

--- a/app/views/products/_category.html.erb
+++ b/app/views/products/_category.html.erb
@@ -1,4 +1,4 @@
-<li class="w-full p-2 grow hover:shadow-md">
+<li class="w-full p-2 grow rounded-3xl hover:shadow-md">
   <%= link_to product_category_path(category.id) do%>
     <div class="mx-auto">
       <%= image_tag "category_icon/#{convert_category_name(category.content)}" ,class: "rounded-3xl", alt: "category_#{category.content}" %>

--- a/app/views/products/_product.html.erb
+++ b/app/views/products/_product.html.erb
@@ -1,13 +1,13 @@
 <section class="border-b border-gray-200 rounded-sm shadow-md">
-  <header class= "mb-2">
-    <div>
-      <%= link_to product_path(product) do %>
-        <img src="https://picsum.photos/200/" class="w-full rounded-t-sm">
-      <% end %>
-    </div>
-  </header>
-  <section class= "flex flex-col justify-between h-24 px-2">
-    <h2 class= "flex-1 text-sm line-clamp-2"><%= product.name %></h2>
-    <div class="mb-2 font-semibold text-marche_orange text-md">$<%= product.sale_infos.first.price %></div>
-  </section>
+  <%= link_to product_path(product) do %>
+    <header class= "mb-2">
+      <div>
+          <img src="https://picsum.photos/200/" class="w-full rounded-t-sm">
+      </div>
+    </header>
+    <section class= "flex flex-col justify-between h-24 px-2">
+      <h2 class= "flex-1 text-sm line-clamp-2"><%= product.name %></h2>
+      <div class="mb-2 font-semibold text-marche_orange text-md">$<%= product.sale_infos.first.price %></div>
+    </section>
+  <% end %>
 </section>

--- a/app/views/products/index.html.erb
+++ b/app/views/products/index.html.erb
@@ -19,16 +19,98 @@
 </div>
 <%# 商品分類 %>
 <section class="flex flex-col w-10/12 mx-auto my-6">
-  <header>
-    <h2>商品分類</h2>
-  </header>
+  <h2 class="self-start text-xl font-bold text-marche_orange">商品分類</h2>
   <ul class="grid grid-cols-11">
     <%= render partial: 'category', collection: @categories, as: :category %>
   </ul>
 </section>
+<%# 熱門商品%>
+<div class="container w-10/12 mx-auto my-10">
+  <h2 class="self-end mb-2 text-xl font-bold text-marche_orange">熱門商品</h2>
+  <div class="slider_hot">
+    <div class="w-full">
+      <%= image_tag "https://picsum.photos/200/200?random=1" ,class: "w-full", alt: "pic-1" %>
+    </div>
+    <div class="w-full">
+      <%= image_tag "https://picsum.photos/200/200?random=2" ,class: "w-full", alt: "pic-2" %>
+    </div>
+    <div class="w-full">
+      <%= image_tag "https://picsum.photos/200/200?random=3" ,class: "w-full", alt: "pic-3" %>
+    </div>
+    <div class="w-full">
+      <%= image_tag "https://picsum.photos/200/200?random=4" ,class: "w-full", alt: "pic-4" %>
+    </div>
+    <div class="w-full">
+      <%= image_tag "https://picsum.photos/200/200?random=5" ,class: "w-full", alt: "pic-5" %>
+    </div>
+    <div class="w-full">
+      <%= image_tag "https://picsum.photos/200/200?random=6" ,class: "w-full", alt: "pic-6" %>
+    </div>
+    <div class="w-full">
+      <%= image_tag "https://picsum.photos/200/200?random=7" ,class: "w-full", alt: "pic-7" %>
+    </div>
+    <div class="w-full">
+      <%= image_tag "https://picsum.photos/200/200?random=8" ,class: "w-full", alt: "pic-8" %>
+    </div>
+    <div class="w-full">
+      <%= image_tag "https://picsum.photos/200/200?random=9" ,class: "w-full", alt: "pic-9" %>
+    </div>
+    <div class="w-full">
+      <%= image_tag "https://picsum.photos/200/200?random=10" ,class: "w-full", alt: "pic-10" %>
+    </div>
+    <div class="w-full">
+      <%= image_tag "https://picsum.photos/200/200?random=11" ,class: "w-full", alt: "pic-11" %>
+    </div>
+    <div class="w-full">
+      <%= image_tag "https://picsum.photos/200/200?random=12" ,class: "w-full", alt: "pic-12" %>
+    </div>
+  </div>
+</div>
+<%# 最新商品%>
+<div class="container w-10/12 mx-auto my-10">
+  <h2 class="self-end mb-2 text-xl font-bold text-marche_orange">最新商品</h2>
+  <div class="slider_hot">
+    <div class="w-full">
+      <%= image_tag "https://picsum.photos/200/200?random=12" ,class: "w-full", alt: "pic-12" %>
+    </div>
+    <div class="w-full">
+      <%= image_tag "https://picsum.photos/200/200?random=11" ,class: "w-full", alt: "pic-11" %>
+    </div>
+    <div class="w-full">
+      <%= image_tag "https://picsum.photos/200/200?random=10" ,class: "w-full", alt: "pic-10" %>
+    </div>
+    <div class="w-full">
+      <%= image_tag "https://picsum.photos/200/200?random=9" ,class: "w-full", alt: "pic-9" %>
+    </div>
+    <div class="w-full">
+      <%= image_tag "https://picsum.photos/200/200?random=8" ,class: "w-full", alt: "pic-8" %>
+    </div>
+    <div class="w-full">
+      <%= image_tag "https://picsum.photos/200/200?random=7" ,class: "w-full", alt: "pic-7" %>
+    </div>
+    <div class="w-full">
+      <%= image_tag "https://picsum.photos/200/200?random=6" ,class: "w-full", alt: "pic-6" %>
+    </div>
+    <div class="w-full">
+      <%= image_tag "https://picsum.photos/200/200?random=5" ,class: "w-full", alt: "pic-5" %>
+    </div>
+    <div class="w-full">
+      <%= image_tag "https://picsum.photos/200/200?random=4" ,class: "w-full", alt: "pic-4" %>
+    </div>
+    <div class="w-full">
+      <%= image_tag "https://picsum.photos/200/200?random=3" ,class: "w-full", alt: "pic-3" %>
+    </div>
+    <div class="w-full">
+      <%= image_tag "https://picsum.photos/200/200?random=2" ,class: "w-full", alt: "pic-2" %>
+    </div>
+    <div class="w-full">
+      <%= image_tag "https://picsum.photos/200/200?random=1" ,class: "w-full", alt: "pic-1" %>
+    </div>
+  </div>
+</div>
 <%# 商品列表 %>
 <div class="flex justify-between w-10/12 mx-auto">
-  <h1 class="self-end mb-2 text-xl font-bold text-marche_orange">商品列表</h1>
+  <h2 class="self-end mb-2 text-xl font-bold text-marche_orange">推薦商品</h2>
   <%= link_to '新增商品', new_product_path, class: "self-end mb-2 btn bg-marche_orange hover:bg-marche_orange100 border-none font-normal" %>
 </div>
 <div class="grid w-10/12 gap-4 mx-auto sm:grid-cols-3 lg:grid-cols-5 md:grid-cols-4 xl:grid-cols-6">


### PR DESCRIPTION
1.首頁商品呈現區塊修改
首頁商品目前要呈現三個區塊，熱門商品區、最新商品區、隨機推薦商品區（目前只加了layout，沒有實際功能）
2.輪播左右按鈕位置樣式調整
將輪播的左右切換按鈕位置調到圖片內，並且把按鈕放大

https://github.com/5xRuby13thMarche/Marche/assets/130286574/d555f5e4-9597-40c5-89d7-605149ba8f9f



