### PR TITLE
購物車icon數字懸浮樣式修改

### DIFF
--- a/app/views/layouts/_page_header.html.erb
+++ b/app/views/layouts/_page_header.html.erb
@@ -14,7 +14,7 @@
   </div>
   <%# 購物車 %>
   <div class="indicator" data-controller="cart--icon" data-action="update--cart@window->cart--icon#updateCart">
-    <span class="relative left-12 top-4 indicator-item badge badge-secondary" data-cart--icon-target="cartNum" data-product-count="<%= get_user_cart_products_num() %>">
+    <span class="relative left-12 top-4 px-[5px] bg-marche_white text-marche_orange indicator-item badge badge-secondary" data-cart--icon-target="cartNum" data-product-count="<%= get_user_cart_products_num() %>">
       <%= get_user_cart_products_num %>
     </span>
     <%= link_to(raw('<svg xmlns="http://www.w3.org/2000/svg" width="34" height="34" viewBox="0 0 24 24" class="mt-3 mr-3"><path d="M21.5,15a3,3,0,0,0-1.9-2.78l1.87-7a1,1,0,0,0-.18-.87A1,1,0,0,0,20.5,4H6.8L6.47,2.74A1,1,0,0,0,5.5,2h-2V4H4.73l2.48,9.26a1,1,0,0,0,1,.74H18.5a1,1,0,0,1,0,2H5.5a1,1,0,0,0,0,2H6.68a3,3,0,1,0,5.64,0h2.36a3,3,0,1,0,5.82,1,2.94,2.94,0,0,0-.4-1.47A3,3,0,0,0,21.5,15Zm-3.91-3H9L7.34,6H19.2ZM9.5,20a1,1,0,1,1,1-1A1,1,0,0,1,9.5,20Zm8,0a1,1,0,1,1,1-1A1,1,0,0,1,17.5,20Z"></path></svg>'), cart_path, class: "fill-marche_white mb-4 ml-3") %>


### PR DESCRIPTION
修改購物車icon懸浮數字的樣式，修改前為桃紅色，修改後為白色
![截圖 2023-05-11 下午6 36 14](https://github.com/5xRuby13thMarche/Marche/assets/130286574/75784e99-28f4-4404-9b84-445afe19c199)
![截圖 2023-05-11 下午6 37 29](https://github.com/5xRuby13thMarche/Marche/assets/130286574/b4486f3d-8a7f-4ccc-8c72-bc3add9e4b07)
