### PR TITLE
Add ability for users to view their liked products and switch between tabs

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -2,6 +2,7 @@ class ProductsController < ApplicationController
   before_action :set_product, only: [:show, :edit, :update, :destroy]
   before_action :set_q_ransack, only: [:index, :show, :search, :category]
   before_action :set_user_cart_product_num, only: [:index, :show, :search, :category]
+  layout 'backend', only: [:create]
   
   def index
     @products = Product.includes(images_attachments: :blob).includes(:sale_infos)
@@ -53,6 +54,7 @@ class ProductsController < ApplicationController
   def create
     @product = Product.new(product_params)
     @product.shop_id = current_user.shop.id
+    @shop = current_user.shop
     if @product.save
       redirect_to root_path, notice: "新增商品成功" 
     else

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -3,9 +3,6 @@ class UsersController < ApplicationController
 
   def show_like
     @products = current_user.liked_products
-    p '-'*40
-    p @products
-    p '-'*40
   end
 
   

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,9 +1,12 @@
 class UsersController < ApplicationController
-  # before_action :authenticate_user!
+  before_action :authenticate_user!
 
-  # def show_orders
-  #   @orders = current_user.orders
-  # end
+  def show_like
+    @products = current_user.liked_products
+    p '-'*40
+    p @products
+    p '-'*40
+  end
 
   
 end

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -10,6 +10,10 @@
         <img width="30" height="30" src="https://img.icons8.com/windows/32/ingredients-list.png" alt="ingredients-list"/>
         <%= link_to '我的訂單', show_orders_path %>
       </div>
+      <div class="flex items-center block inline-block px-4 py-2 text-center text-orange-500 border border-white rounded hover:cursor-pointer hover:border-gray-200 hover:bg-gray-200">
+        <img width="30" height="30" src="https://img.icons8.com/windows/32/ingredients-list.png" alt="ingredients-list"/>
+        <%= link_to '我的收藏', show_like_path %>
+      </div>
     </div>
   </div>
   

--- a/app/views/shared/_backend_sidebar.html.erb
+++ b/app/views/shared/_backend_sidebar.html.erb
@@ -10,7 +10,7 @@
       <li>
         <h2 class="block p-1 mt-2 ml-1 text-base cursor-pointer text-marche_backend_primary w-30">訂單管理</h2>
         <li>
-          <%= link_to "我的銷售", shop_order_path(9) , class: "mt-2 ml-4 py-1 border-l-2 border-marche_backend_blue text-sm text-gray-300 cursor-pointer hover:text-marche_backend_blue500 hover:border-marche_backend_blue500 justify-center flex" %>
+          <%= link_to "我的銷售", shop_order_path(@shop.id) , class: "mt-2 ml-4 py-1 border-l-2 border-marche_backend_blue text-sm text-gray-300 cursor-pointer hover:text-marche_backend_blue500 hover:border-marche_backend_blue500 justify-center flex" %>
         </li>
       </li>
       <li>

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -27,6 +27,7 @@
           <li>
             <%= link_to "我的帳戶", edit_user_registration_path, class: "active:bg-marche_orange" %>
             <%= link_to "我的訂單", show_orders_path, class: "active:bg-marche_orange" %>
+            <%= link_to "我的收藏", show_like_path, class: "active:bg-marche_orange" %>
             <%= link_to "登出", destroy_user_session_path, data: { turbo_method: :delete,  confirm: '是否確定登出'}, class: "active:bg-marche_orange" %>
           </li>
         <% else %>

--- a/app/views/users/_product.html.erb
+++ b/app/views/users/_product.html.erb
@@ -1,0 +1,8 @@
+<div class="mt-2 mb-4 border-2 border-grey">
+
+  <div class="flex items-center justify-between px-3 bg-gray-100">
+    <h1 class="m-2 text-xl text-left">我的收藏</h1>
+    <p></p>
+  </div>
+    
+</div>        

--- a/app/views/users/_product.html.erb
+++ b/app/views/users/_product.html.erb
@@ -1,8 +1,0 @@
-<div class="mt-2 mb-4 border-2 border-grey">
-
-  <div class="flex items-center justify-between px-3 bg-gray-100">
-    <h1 class="m-2 text-xl text-left">我的收藏</h1>
-    <p></p>
-  </div>
-    
-</div>        

--- a/app/views/users/show_like.html.erb
+++ b/app/views/users/show_like.html.erb
@@ -5,23 +5,23 @@
         <img width="30" height="30" src="https://img.icons8.com/ios-glyphs/30/user--v1.png" alt="user--v1"/>
         <%= link_to '我的帳戶', edit_user_registration_path %>
       </div>
-      <div class="flex items-center inline-block px-4 py-2 text-center text-gray-400 cursor-not-allowed">
-        <img width="30" height="30" src="https://img.icons8.com/windows/32/ingredients-list.png" alt="ingredients-list"/>
-        <p class="inline-block">我的訂單</p>
-      </div>
       <div class="flex items-center block inline-block px-4 py-2 text-center text-orange-500 border border-white rounded hover:cursor-pointer hover:border-gray-200 hover:bg-gray-200">
         <img width="30" height="30" src="https://img.icons8.com/windows/32/ingredients-list.png" alt="ingredients-list"/>
-        <%= link_to '我的收藏', show_like_path %>
+        <%= link_to '我的訂單', show_orders_path %>
+      </div>
+      <div class="flex items-center inline-block px-4 py-2 text-center text-gray-400 cursor-not-allowed">
+        <img width="30" height="30" src="https://img.icons8.com/windows/32/ingredients-list.png" alt="ingredients-list"/>
+        <p class="inline-block">我的收藏</p>
       </div>
     </div>
   </div>
   
   <div class="w-10/12 mx-auto mt-1 0">
-    <h1 class="mt-4 mb-4 text-2xl font-bold">我的訂單</h1>
-    <% if @orders.present? %>
-      <%= render partial:'orders/order', collection: @orders, as: :order %>
+    <h1 class="mt-4 mb-4 text-2xl font-bold">我的收藏</h1>
+    <% if @products.present? %>
+      <%= render partial:'products/product', collection: @products %>
     <% else %>
-      <button><%= link_to '您目前沒有訂單，去 Marche 市集逛逛', root_path, class: "px-4 py-2 m-2 mt-4 text-sm font-bold border-orange-200 rounded text-marche_white bg-marche_orange hover:bg-marche_orange100 hover:text-black-100 hover:cursor-pointer" %></button>
+      <button><%= link_to '您目前沒有收藏商品，去 Marche 市集逛逛', root_path, class: "px-4 py-2 m-2 mt-4 text-sm font-bold border-orange-200 rounded text-marche_white bg-marche_orange hover:bg-marche_orange100 hover:text-black-100 hover:cursor-pointer" %></button>
     <% end %>
   </div>
 </div>

--- a/app/views/users/show_like.html.erb
+++ b/app/views/users/show_like.html.erb
@@ -19,7 +19,9 @@
   <div class="w-10/12 mx-auto mt-1 0">
     <h1 class="mt-4 mb-4 text-2xl font-bold">我的收藏</h1>
     <% if @products.present? %>
-      <%= render partial:'products/product', collection: @products %>
+      <div class="grid w-10/12 gap-4 sm:grid-cols-3 lg:grid-cols-5 md:grid-cols-4 xl:grid-cols-6">
+        <%= render partial:'products/product', collection: @products %>
+      </div>
     <% else %>
       <button><%= link_to '您目前沒有收藏商品，去 Marche 市集逛逛', root_path, class: "px-4 py-2 m-2 mt-4 text-sm font-bold border-orange-200 rounded text-marche_white bg-marche_orange hover:bg-marche_orange100 hover:text-black-100 hover:cursor-pointer" %></button>
     <% end %>

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -10,3 +10,52 @@ zh-TW:
           attributes:
             current_password:
               blank: "請輸入您的當前密碼"
+        product:
+          attributes:
+            name:
+              blank: "名稱不能為空白"
+            category_id:
+              blank: "分類不能為空白"
+        sale_info:
+          attributes:
+            spec:
+              blank: "銷售資訊中的規格不能為空白"
+      messages:
+        record_invalid: 校驗失敗：%{errors}
+        restrict_dependent_destroy:
+          has_one: 由於%{record}需要此記錄，所以無法移除記錄
+          has_many: 由於%{record}需要此記錄，所以無法移除記錄
+    
+      format: "%{attribute}%{message}"
+      messages:
+        accepted: 必須是可被接受的
+        blank: 不能為空白
+        confirmation: 與%{attribute}須一致
+        empty: 不能留空
+        equal_to: 必須等於%{count}
+        even: 必須是偶數
+        exclusion: 是被保留的關鍵字
+        greater_than: 必須大於%{count}
+        greater_than_or_equal_to: 必須大於或等於%{count}
+        inclusion: 沒有包含在列表中
+        invalid: 是無效的
+        less_than: 必須小於%{count}
+        less_than_or_equal_to: 必須小於或等於%{count}
+        model_invalid: 校驗失敗：%{errors}
+        not_a_number: 不是數字
+        not_an_integer: 必須是整數
+        odd: 必須是奇數
+        other_than: 不可以是%{count}個字
+        present: 必須是空白
+        required: 必須存在
+        taken: 已經被使用
+        too_long: 過長（最長是%{count}個字）
+        too_short: 過短（最短是%{count}個字）
+        wrong_length: 字數錯誤（必須是%{count}個字）
+      template:
+        body: 以下欄位發生問題：
+        header: 有%{count}個錯誤發生使得「%{model}」無法被儲存。
+
+
+
+      

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -3,3 +3,10 @@ zh-TW:
         pagination:
           prev: "上一頁"
           next: "下一頁"
+  activerecord:
+    errors:
+      models:
+        user:
+          attributes:
+            current_password:
+              blank: "請輸入您的當前密碼"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -65,5 +65,8 @@ Rails.application.routes.draw do
     delete '/carts/delete_all_items', to: 'carts#destroy_items'
   end
 
+  # 收藏商品
+  get '/users/liked_products', to: 'users#show_like', as: :show_like
+
 
 end


### PR DESCRIPTION
Changes made in this Pull Request include:

- Created a new page for users to view their liked products
- Added & Styled a new "View Liked Products" tab to match the existing navigation menu
- Styled the "View Liked Products" page to display products in a grid layout

![Screen Shot 0005-05-14 at 16 02 15](https://github.com/5xRuby13thMarche/Marche/assets/112312121/8e1757ab-4ce6-42d2-9ff7-46d584c4315d)
![Screen Shot 0005-05-14 at 16 02 45](https://github.com/5xRuby13thMarche/Marche/assets/112312121/ec5ef837-9aa8-4bda-9267-22768729a6e0)
![Screen Shot 0005-05-14 at 16 14 55](https://github.com/5xRuby13thMarche/Marche/assets/112312121/e91d986e-5817-4a96-b4b1-792dbd56f1a3)

![Screen Shot 0005-05-14 at 16 04 18](https://github.com/5xRuby13thMarche/Marche/assets/112312121/18317fc6-6262-417d-a258-6705b537f82d)
