### PR TITLE
Fix footer position using flexbox

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -12,10 +12,12 @@
     <link rel="stylesheet" type="text/css" href="//cdn.jsdelivr.net/npm/slick-carousel@1.8.1/slick/slick.css"/>
     <link rel="stylesheet" type="text/css" href="//cdn.jsdelivr.net/npm/slick-carousel@1.8.1/slick/slick-theme.css"/>
   </head>
-  <body>
+  <body class="flex flex-col min-h-screen">
     <%= render 'shared/navbar' %>
-    <%= yield %>
-    <%= render 'shared/footer' %>
+    <div class="flex-grow">
+      <%= yield %>
+    </div>
+    <%= render 'shared/footer', class: "flex-shrink-0 flex-basis-0" %>
     <%# Banner JQuery%>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.5.1/jquery.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/slick-carousel/1.8.1/slick.js"></script>


### PR DESCRIPTION
This PR updates the CSS for the footer to use flexbox and ensure that it stays at the bottom of the page even when there is not enough content to fill the entire viewport.

Before:
![Screen Shot 0005-05-14 at 16 02 45](https://github.com/5xRuby13thMarche/Marche/assets/112312121/ec5ef837-9aa8-4bda-9267-22768729a6e0)

After:
![Screen Shot 0005-05-14 at 18 45 12](https://github.com/5xRuby13thMarche/Marche/assets/112312121/7f87d409-4ce0-46a6-a9c4-8d1f0fdda9ca)
![Screen Shot 0005-05-14 at 18 45 27](https://github.com/5xRuby13thMarche/Marche/assets/112312121/4f8bf787-0c6c-4531-9099-b506ba5afda8)
![Screen Shot 0005-05-14 at 18 45 49](https://github.com/5xRuby13thMarche/Marche/assets/112312121/e5bcf820-b059-48eb-b88e-f3be1a96cc2c)
