### PR TITLE
fix: Update Mailgun domain settings and default time zone

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -17,8 +17,7 @@ module Marche
     #
     # These settings can be overridden in specific environments using the files
     # in config/environments, which are processed later.
-    #
-    # config.time_zone = "Central Time (US & Canada)"
+    config.time_zone = 'Asia/Taipei'
     # config.eager_load_paths << Rails.root.join("extras")
 
     config.assets.css_compressor = nil

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -82,7 +82,7 @@ Rails.application.configure do
   config.action_mailer.smtp_settings = {
   address:              'smtp.mailgun.org',
   port:                 587,
-  domain:               'https://marche.herokuapp.com/',
+  domain:               'https://www.marche.asia/',
   user_name:            ENV['user_name'],
   password:             ENV['password'],
   authentication:       'plain',


### PR DESCRIPTION
Changes Made:

- Updated Mailgun domain settings
- Modified the default time zone configuration to 'Asia/Taipei' (+08:00)

the current time displayed when creating a comment (confirm the accurate time representation)
![Screen Shot 0005-05-17 at 10 25 58](https://github.com/5xRuby13thMarche/Marche/assets/112312121/637efd67-90c2-43e3-a11f-dc90d0ca5b5a)
