### PR TITLE
fix: Update user registration to set name from email prefix

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,12 +22,12 @@ gem "image_processing", ">= 1.2"
 gem "aws-sdk-s3", require: false
 gem "ransack", "~> 4.0"
 gem "tailwindcss-rails", "~> 2.0"
-gem "faker", "~> 3.2"
 
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
+  gem "faker", "~> 3.2"
 end
 
 group :development do

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -12,7 +12,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
   # POST /resource
   def create
     super do |resource|
-      resource.name = "@#{Faker::Internet.password(min_length: 8)}" #帶修改
+      resource.name = "@" + params[:user][:email].split('@').first
       resource.save
     end
   end


### PR DESCRIPTION
This commit modifies the user registration process to set the user's name by using the prefix of their email address. 

With this update, when a user signs up, their name will be assigned with the "@" symbol followed by the prefix of their email address. For example, if the email is "marushe@gmail.com", the name will be set to "@marushe".
