### PR TITLE
賣場中心頁面調整，商店資訊加上圖片

### DIFF
--- a/app/views/layouts/shop.html.erb
+++ b/app/views/layouts/shop.html.erb
@@ -9,7 +9,7 @@
     <%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>
     <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload' %>
   </head>
-  <body class="h-full bg-cover bg-sky-100">
+  <body class="h-full min-h-screen bg-cover bg-sky-100">
     <%= render 'shared/shop_navbar' %>
     <%= yield %>
   </body>

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -1,9 +1,9 @@
 <div class="flex w-full bg-marche_orange">
   <nav class="w-full items-center flex flex-wrap justify-end content-center mx-[30px] 2xl:mx-[140px] xl:mx-[132px] lg:mx-[120px] md:mx-[116px] sm:mx-[60px]">
     <% if current_user&.shop&.present? %>
-      <%= link_to "賣家中心", shops_path , class: "hidden md:inline-block text-gray-100 text-xs mr-auto border border-x-0 border-t-0"%>
+      <%= link_to "賣家中心", shops_path , class: "hidden md:inline-block text-gray-100 text-xs mr-auto"%>
     <% else %>
-      <%= link_to "賣家中心", new_shop_path , class: "hidden md:inline-block text-gray-100 text-xs mr-auto border border-x-0 border-t-0"%>
+      <%= link_to "賣家中心", new_shop_path , class: "hidden md:inline-block text-gray-100 text-xs mr-auto"%>
     <% end %>
     <%= link_to "首頁", root_path , class: "px-4 text-gray-100 text-xs"%>
     <!-- 顯示使用者名稱 or 未登入字樣-->

--- a/app/views/shops/edit.html.erb
+++ b/app/views/shops/edit.html.erb
@@ -1,8 +1,8 @@
 <div class="relative flex">
   <%= render 'shared/shop_sidebar'%>
-  <div class="w-5/6 mt-[84px] ml-auto h-screen bg-sky-100">
+  <div class="w-5/6 mt-[84px] ml-auto h-full bg-sky-100">
       <h1 class="self-end w-5/6 pl-3 mx-auto mt-5 text-3xl font-bold text-sky-800">賣場簡介</h1>
-    <section class="w-5/6 mx-auto mt-3 bg-white rounded-md shadow-xl">
+    <section class="w-5/6 mx-auto mt-3 mb-16 bg-white rounded-md shadow-xl">
       <div class="w-full px-6 py-3 mx-auto">
         <h2 class="w-full text-xl font-bold text-marche_shop_black">基本資料</h2>
         <div class="w-full mx-auto" data-controller="user--avatar">

--- a/app/views/shops/order.html.erb
+++ b/app/views/shops/order.html.erb
@@ -1,17 +1,16 @@
 <div class="relative flex">
   <%= render 'shared/shop_sidebar' %>
-  <div class="w-5/6 ml-auto mt-[84px] bg-sky-100 h-screen">
+  <div class="w-5/6 ml-auto mt-[84px] bg-sky-100 h-full">
     <h1 class="self-end w-5/6 pl-3 mx-auto mt-5 text-3xl font-bold text-sky-800">我的銷售</h1>
-    <div class="w-5/6 mx-auto mt-3">
-      <div class="tabs ">
-        <%= link_to '未出貨', order_shop_path(@shop), class: "tab tab-lifted tab-active"%>
+    <div class="w-5/6 mx-auto mt-3 mb-16">
+      <div class="tabs">
+        <%= link_to '未出貨', order_shop_path(@shop), class: "tab tab-lifted tab-active text-sky-700 text-base font-semibold"%>
         <%= link_to '已出貨', shipped_shop_path(@shop), class: "tab tab-lifted"%>
       </div>
       <table class="table w-full mx-auto shadow-xl table-compact">
         <!-- head -->
         <thead class="">
           <tr class="text-center">
-            <th></th>
             <th class="text-base">商品狀態</th>
             <th class="text-base">出售時間</th>
             <th class="text-base">產品名稱</th>
@@ -23,8 +22,7 @@
         </thead>
         <tbody>
           <% @shop_orders.each_with_index do |shop_orders, index| %>
-            <tr class="hover" data-controller="shop--order" data-order-product-id="<%= shop_orders.id %>"> 
-              <td><%= index + 1 %></td>
+            <tr class="text-center hover" data-controller="shop--order" data-order-product-id="<%= shop_orders.id %>"> 
               <td data-shop--order-traget="status"><%= shop_orders.shipping_status %></td>
               <td><%= format_date_with_time(shop_orders.updated_at) %></td>
               <td><%= shop_orders.product.name %></td>

--- a/app/views/shops/products.html.erb
+++ b/app/views/shops/products.html.erb
@@ -1,8 +1,8 @@
 <div class="relative flex">
   <%= render 'shared/shop_sidebar' %>
-  <div class="w-5/6 ml-auto mt-[84px] bg-sky-100 h-screen">
+  <div class="w-5/6 ml-auto mt-[84px] bg-sky-100 h-full">
     <h1 class="self-end w-5/6 pl-3 mx-auto mt-5 text-3xl font-bold text-sky-800">我的商品</h1>
-    <table class="table w-5/6 mx-auto mt-3 shadow-xl table-compact">
+    <table class="table w-5/6 mx-auto mt-3 shadow-xl table-compact mb-28">
       <!-- head -->
       <thead>
         <tr class="text-center">
@@ -19,7 +19,7 @@
         <% shop_products.sale_infos.each do |s| %>
         <tbody>
           <tr class="text-center hover"> 
-            <td class="w-1/6">
+            <td class="w-20 h-20">
             <%= link_to product_path(shop_products.id) do %>
               <%= product_image(shop_products) %>
             <% end %>

--- a/app/views/shops/shipped.html.erb
+++ b/app/views/shops/shipped.html.erb
@@ -1,30 +1,28 @@
 <div class="relative flex">
   <%= render 'shared/shop_sidebar' %>
-  <div class="w-5/6 ml-auto h-screen mt-[84px] bg-sky-100">
+  <div class="w-5/6 ml-auto h-full mt-[84px] bg-sky-100">
     <h1 class="self-end w-5/6 pl-3 mx-auto mt-5 text-3xl font-bold text-sky-800">我的銷售</h1>
-    <div class="w-5/6 mx-auto mt-3">
-      <div class="tabs ">
+    <div class="w-5/6 mx-auto mt-3 mb-16">
+      <div class="tabs">
         <%= link_to '未出貨', order_shop_path(@shop), class: "tab tab-lifted"%>
-        <%= link_to '已出貨', shipped_shop_path(@shop), class: "tab tab-lifted tab-active"%>
+        <%= link_to '已出貨', shipped_shop_path(@shop), class: "tab tab-lifted tab-active text-sky-700 text-base font-semibold"%>
       </div>
       <table class="table w-full mx-auto shadow-xl table-compact">
         <!-- head -->
         <thead class="">
-          <tr>
-            <th class="rounded-tl-none"></th>
-            <th>商品狀態</th>
-            <th>出售時間</th>
-            <th>出貨時間</th>
-            <th>產品名稱</th>
-            <th>產品規格</th>
-            <th>出售數量</th>
-            <th>出售總額</th>
+          <tr class="text-center">
+            <th class="text-base">商品狀態</th>
+            <th class="text-base">出售時間</th>
+            <th class="text-base">出貨時間</th>
+            <th class="text-base">產品名稱</th>
+            <th class="text-base">產品規格</th>
+            <th class="text-base">出售數量</th>
+            <th class="text-base">出售總額</th>
           </tr>
         </thead>
         <tbody>
           <% @shop_orders.each_with_index do |shop_orders, index| %>
-            <tr class="hover" data-controller="shop--order" data-order-product-id="<%= shop_orders.id %>"> 
-              <td><%= index + 1 %></td>
+            <tr class="text-center hover" data-controller="shop--order" data-order-product-id="<%= shop_orders.id %>"> 
               <td data-shop--order-traget="status"><%= shop_orders.shipping_status %></td>
               <td><%= format_date_with_time(shop_orders.created_at) %></td>
               <td><%= format_date_with_time(shop_orders.updated_at) %></td>

--- a/app/views/shops/show.html.erb
+++ b/app/views/shops/show.html.erb
@@ -1,8 +1,11 @@
 <%= render partial: 'layouts/page_header', locals: {ransack_q: @ransack_q} %>
 <%# 標題區 %>
-<div class="flex items-center w-full mt-8 mb-1 ml-2 bg-red-500 sm:mx-auto sm:w-10/12">
+<div class="flex items-center w-full mt-6 rounded bg-marche_orange sm:mx-auto sm:w-10/12">
   <%# 標題 %>
-  <h1 class="text-xl font-bold text-marche_black"><%= @shop.name %></h1>
+  <div class="w-10 my-2 ml-2 mr-4 border rounded-full">
+    <%= logo(@shop, size: [80, 80]) %>
+  </div>
+  <h1 class="py-2 text-xl font-bold text-gray-50"><%= @shop.name %></h1>
 </div>
 <%# 分類區 %>
 <div class="flex w-full mx-auto sm:w-10/12">


### PR DESCRIPTION
1.修正賣場中心資訊較少時背景顯示問題
2.移除我的商品和我的銷售的流水編號
3.優化我的銷售頁面頁籤顯示
4.商店資訊加上圖片
<img width="372" alt="截圖 2023-05-21 下午7 12 35" src="https://github.com/5xRuby13thMarche/Marche/assets/130286574/8b99c4e6-d0d7-48c2-af05-68cad786c824">
<img width="1127" alt="截圖 2023-05-21 下午8 43 27" src="https://github.com/5xRuby13thMarche/Marche/assets/130286574/6b559925-8ee3-4925-a2cf-a6b673763c40">
