### PR TITLE
不用登入也可將商品加入購物車

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -48,10 +48,13 @@
     @apply z-10 w-12 h-8 p-0 text-center border-gray-300
   }
   .checkout-btn{
-    @apply bg-marche_orange hover:bg-marche_orange100 hover:cursor-pointer -mr-[1px] py-[30px] md:p-2 md:md:me-5 rounded-none md:rounded text-white text-sm w-28
+    @apply bg-marche_orange hover:bg-marche_orange100 hover:cursor-pointer px-2 h-full md:h-fit md:mx-4 mr-0 md:rounded text-white text-sm md:py-2 w-32
   }
   .checkout-disabled-btn{
-    @apply bg-slate-400 cursor-not-allowed -mr-[1px] py-[30px] md:p-2 md:md:me-5 rounded-none md:rounded text-white text-sm w-28
+    @apply bg-slate-400 cursor-not-allowed md:py-2 md:rounded text-white text-sm px-2 h-full md:h-fit md:mx-4 mr-0 w-32
+  }
+  .login-link{
+    @apply bg-marche_orange hover:bg-marche_orange100 hover:cursor-pointer px-2 h-full md:h-fit md:mx-4 mr-0 md:rounded text-white text-sm md:py-2 w-32
   }
 
   /* 去除number input 預設的上下箭頭 */

--- a/app/controllers/api/cart_products_controller.rb
+++ b/app/controllers/api/cart_products_controller.rb
@@ -6,7 +6,7 @@ class Api::CartProductsController < ApplicationController
     else
       session_cart = Cart.create()
       session[:_cart_] =  session_cart.id
-      session_cart.cart_products.create(quantity: 1, sale_info_id: params[:sale_info_id])
+      session_cart.cart_products.create(quantity: params[:quantity], sale_info_id: params[:sale_info_id])
       message = {ok: 'create success！'}
     end
     render json: message

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,6 +3,8 @@ class ApplicationController < ActionController::Base
   def set_cart_num
     if user_signed_in?
       @user_cart_product_num = current_user.cart.cart_products.count
+    elsif session[:_cart_].present?
+      @user_cart_product_num = Cart.find(session[:_cart_]).cart_products.count
     end
   end
 

--- a/app/controllers/carts_controller.rb
+++ b/app/controllers/carts_controller.rb
@@ -1,6 +1,6 @@
 class CartsController < ApplicationController
   before_action :set_q_ransack, only: [:index]
-  # before_action :set_cart_num, only: [:index]
+  before_action :set_cart_num, only: [:index]
 
   def index
     if user_signed_in?
@@ -9,8 +9,6 @@ class CartsController < ApplicationController
     elsif session[:_cart_].present?
       @cart = Cart.find(session[:_cart_])
       @cart_products = @cart.cart_products.includes(sale_info: [:product])
-    else
-      @cart
     end
   end
 end

--- a/app/controllers/carts_controller.rb
+++ b/app/controllers/carts_controller.rb
@@ -1,10 +1,16 @@
 class CartsController < ApplicationController
-  before_action :authenticate_user!
   before_action :set_q_ransack, only: [:index]
-  before_action :set_cart_num, only: [:index]
+  # before_action :set_cart_num, only: [:index]
 
   def index
-    @cart = current_user.cart
-    @cart_products = @cart.cart_products.includes(sale_info: [:product])
+    if user_signed_in?
+      @cart = current_user.cart
+      @cart_products = @cart.cart_products.includes(sale_info: [:product])
+    elsif session[:_cart_].present?
+      @cart = Cart.find(session[:_cart_])
+      @cart_products = @cart.cart_products.includes(sale_info: [:product])
+    else
+      @cart
+    end
   end
 end

--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -1,6 +1,6 @@
 class CategoriesController < ApplicationController
   before_action :set_q_ransack, only: [:show]
-  before_action :set_cart_num, only: [:show]
+  # before_action :set_cart_num, only: [:show]
   def show
     @parent_category = Category.find(params[:id])
     @child_categories = @parent_category.children

--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -1,6 +1,6 @@
 class CategoriesController < ApplicationController
   before_action :set_q_ransack, only: [:show]
-  # before_action :set_cart_num, only: [:show]
+  before_action :set_cart_num, only: [:show]
   def show
     @parent_category = Category.find(params[:id])
     @child_categories = @parent_category.children

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -4,6 +4,7 @@ class OrdersController < ApplicationController
   before_action :set_cart_num, only: [:new, :index, :show, :search]
   skip_before_action :verify_authenticity_token, only: [:notify]
 
+  # 結帳頁面
   def new
     @cart = current_user.cart
     @cart_products =  @cart.cart_products.includes(sale_info: [:product]).where(id: params[:cart_product_ids])

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -1,7 +1,7 @@
 class ProductsController < ApplicationController
   before_action :set_product, only: [:show, :edit, :update, :destroy]
   before_action :set_q_ransack, only: [:index, :show, :search]
-  before_action :set_cart_num, only: [:index, :show, :search]
+  # before_action :set_cart_num, only: [:index, :show, :search]
   before_action :shop_params,only: [:new, :create, :edit, :update, :destroy]
   layout 'shop', only: [:new, :create, :update, :destory, :edit]
   

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -1,7 +1,7 @@
 class ProductsController < ApplicationController
   before_action :set_product, only: [:show, :edit, :update, :destroy]
   before_action :set_q_ransack, only: [:index, :show, :search]
-  # before_action :set_cart_num, only: [:index, :show, :search]
+  before_action :set_cart_num, only: [:index, :show, :search]
   before_action :shop_params,only: [:new, :create, :edit, :update, :destroy]
   layout 'shop', only: [:new, :create, :update, :destory, :edit]
   

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -12,6 +12,7 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
         cart.delete()
         session.delete(:_cart_)
         @user.save
+
       elsif @user.cart.nil? && session[:_cart_].present?
         # session的購物車指向新使用者
         cart = Cart.find(session[:_cart_])
@@ -22,8 +23,9 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
         @user.build_cart()
         @user.save
       end
-
-      sign_in_and_redirect @user, event: :authentication # this will throw if @user is not activated
+      # sign_in_and_redirect @user, event: :authentication # this will throw if @user is not activated
+      sign_in @user, event: :authentication
+      redirect_to carts_path
       set_flash_message(:notice, :success, kind: "Google") if is_navigational_format?
     else
       session["devise.google_data"] = request.env["omniauth.auth"].except(:extra) # Removing extra as it can overflow some session stores

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -4,8 +4,25 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
   def google_oauth2
     # You need to implement the method below in your model (e.g. app/models/user.rb)
     @user = User.from_omniauth(request.env["omniauth.auth"])
-
     if @user.persisted?
+      if @user.cart.present? && session[:_cart_].present?
+        # session的購物車商品轉給舊使用者
+        cart = Cart.find(session[:_cart_])
+        @user.cart.transfer_cart_products(cart.cart_products)
+        cart.delete()
+        session.delete(:_cart_)
+        @user.save
+      elsif @user.cart.nil? && session[:_cart_].present?
+        # session的購物車指向新使用者
+        cart = Cart.find(session[:_cart_])
+        cart.update(user_id: @user.id)
+        session.delete(:_cart_)
+      else
+        # 生成購物車給新使用者
+        @user.build_cart()
+        @user.save
+      end
+
       sign_in_and_redirect @user, event: :authentication # this will throw if @user is not activated
       set_flash_message(:notice, :success, kind: "Google") if is_navigational_format?
     else
@@ -17,4 +34,5 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
   def failure
     redirect_to root_path
   end
+
 end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -13,14 +13,16 @@ class Users::RegistrationsController < Devise::RegistrationsController
   def create
     super do |resource|
       resource.name = "@" + params[:user][:email].split('@').first
+      resource.save
       if session[:_cart_].present?
         cart = Cart.find(session[:_cart_])
         cart.update(user_id: resource.id)
         session.delete(:_cart_)
+        sign_in resource, event: :authentication
+        redirect_to carts_path and return
       else
-        resource.build_cart()
+        resource.create_cart()
       end
-      resource.save
     end
   end
 

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -13,6 +13,13 @@ class Users::RegistrationsController < Devise::RegistrationsController
   def create
     super do |resource|
       resource.name = "@" + params[:user][:email].split('@').first
+      if session[:_cart_].present?
+        cart = Cart.find(session[:_cart_])
+        cart.update(user_id: resource.id)
+        session.delete(:_cart_)
+      else
+        resource.build_cart()
+      end
       resource.save
     end
   end

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -17,7 +17,9 @@ class Users::SessionsController < Devise::SessionsController
         cart.delete()
         session.delete(:_cart_)
         resource.save
+        redirect_to carts_path and return
       end
+
     end
   end
 

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+class Users::SessionsController < Devise::SessionsController
+  # before_action :configure_sign_in_params, only: [:create]
+
+  # GET /resource/sign_in
+  # def new
+  #   super
+  # end
+
+  # POST /resource/sign_in
+  def create
+    super do |resource|
+      if session[:_cart_].present?
+        cart = Cart.find(session[:_cart_])
+        resource.cart.transfer_cart_products(cart.cart_products)
+        cart.delete()
+        session.delete(:_cart_)
+        resource.save
+      end
+    end
+  end
+
+  # DELETE /resource/sign_out
+  # def destroy
+  #   super
+  # end
+
+  # protected
+
+  # If you have extra params to permit, append them to the sanitizer.
+  # def configure_sign_in_params
+  #   devise_parameter_sanitizer.permit(:sign_in, keys: [:attribute])
+  # end
+end

--- a/app/javascript/controllers/cart/form_controller.js
+++ b/app/javascript/controllers/cart/form_controller.js
@@ -13,6 +13,7 @@ export default class extends Controller {
     "cartItem",
     "submitBtn",
     "allProductsNum",
+    "loginLink",
   ];
   connect() {
     // form表單預設會找尋第一個submit or button進行click事件，因此要preventDefault
@@ -23,6 +24,7 @@ export default class extends Controller {
 
     this.isAllChecked = false;
     this.canPressSubmit = false;
+    this.switchSubmitBtn(this.submitBtnTarget.dataset.signInState === "true");
     this.update();
   }
   update() {
@@ -130,6 +132,16 @@ export default class extends Controller {
       this.allProductsNumTarget.textContent = `全選 ${
         this.checkboxTargets.length - 1
       }`;
+    }
+  }
+  // 未登入時切換結帳按鈕至登入按鈕
+  switchSubmitBtn(state) {
+    if (state) {
+      this.submitBtnTarget.classList.remove("hidden");
+      this.loginLinkTarget.classList.add("hidden");
+    } else {
+      this.submitBtnTarget.classList.add("hidden");
+      this.loginLinkTarget.classList.remove("hidden");
     }
   }
 }

--- a/app/javascript/controllers/product/cart_product_controller.js
+++ b/app/javascript/controllers/product/cart_product_controller.js
@@ -85,7 +85,6 @@ export default class extends Controller {
       });
       if (response.ok) {
         const data = await response.json;
-        if (data.signInState == "false") window.location.href = data.signInUrl;
         Swal.fire({
           icon: "success",
           title: "加入購物車成功",

--- a/app/javascript/scripts/font-awesome.js
+++ b/app/javascript/scripts/font-awesome.js
@@ -9,8 +9,8 @@ import {faX} from "@fortawesome/free-solid-svg-icons";
 import {faMagnifyingGlass} from "@fortawesome/free-solid-svg-icons";
 import {faBackward} from "@fortawesome/free-solid-svg-icons";
 import {faTruck} from "@fortawesome/free-solid-svg-icons";
-import {faGithub} from '@fortawesome/free-brands-svg-icons'
-
+import {faGithub} from "@fortawesome/free-brands-svg-icons";
+import {faCartShopping} from "@fortawesome/free-solid-svg-icons";
 
 library.add(regularHeart);
 library.add(solidHeart);
@@ -19,6 +19,7 @@ library.add(faX);
 library.add(faMagnifyingGlass);
 library.add(faBackward);
 library.add(faTruck);
-library.add(faGithub)
+library.add(faGithub);
+library.add(faCartShopping);
 
 dom.watch();

--- a/app/models/cart.rb
+++ b/app/models/cart.rb
@@ -3,4 +3,15 @@ class Cart < ApplicationRecord
   has_many :cart_products, dependent: :destroy
   has_many :sale_infos, through: :cart_products
 
+  def transfer_cart_products(other_cart_products)
+    other_cart_products.each do |cart_product|
+      found_cart_product = self.cart_products.find_by(sale_info_id: cart_product.sale_info_id)
+      if found_cart_product.present?
+        found_cart_product.update(quantity: found_cart_product.quantity + cart_product.quantity)
+        cart_product.destroy()
+      else
+        cart_product.update(cart_id: self.id)
+      end
+    end
+  end
 end

--- a/app/models/cart.rb
+++ b/app/models/cart.rb
@@ -1,5 +1,5 @@
 class Cart < ApplicationRecord
-  belongs_to :user
+  belongs_to :user, optional: true
   has_many :cart_products, dependent: :destroy
   has_many :sale_infos, through: :cart_products
 

--- a/app/models/cart.rb
+++ b/app/models/cart.rb
@@ -3,6 +3,7 @@ class Cart < ApplicationRecord
   has_many :cart_products, dependent: :destroy
   has_many :sale_infos, through: :cart_products
 
+  # 轉移購物車內的商品到另外一台購物車
   def transfer_cart_products(other_cart_products)
     other_cart_products.each do |cart_product|
       found_cart_product = self.cart_products.find_by(sale_info_id: cart_product.sale_info_id)

--- a/app/models/cart_product.rb
+++ b/app/models/cart_product.rb
@@ -5,4 +5,26 @@ class CartProduct < ApplicationRecord
   def self.cal_total_price(cart_products)
     cart_products.reduce(0) {|acc, cur| acc += cur.quantity * cur.sale_info.price}
   end
+
+  def self.update_or_create_cart_product(user, session_cart_id, params)
+    if user.present?
+      message = create_or_update_cart_product(user.cart, params)
+    else
+      message = create_or_update_cart_product(Cart.find(session_cart_id), params)
+    end
+  end
+
+  private
+
+  def self.create_or_update_cart_product(cart, params)
+    cart_product = cart.cart_products.find_by(sale_info_id: params[:sale_info_id])
+    if cart_product.nil?
+      CartProduct.create(quantity: params[:quantity], sale_info_id: params[:sale_info_id])
+      return {ok: 'create success！'}
+    else
+      cart_product.update(quantity: cart_product.quantity + params[:quantity].to_i)
+      return {ok: 'update success!'}
+    end
+  end
+
 end

--- a/app/models/cart_product.rb
+++ b/app/models/cart_product.rb
@@ -19,7 +19,7 @@ class CartProduct < ApplicationRecord
   def self.create_or_update_cart_product(cart, params)
     cart_product = cart.cart_products.find_by(sale_info_id: params[:sale_info_id])
     if cart_product.nil?
-      CartProduct.create(quantity: params[:quantity], sale_info_id: params[:sale_info_id])
+      CartProduct.create(quantity: params[:quantity], sale_info_id: params[:sale_info_id], cart: cart)
       return {ok: 'create success！'}
     else
       cart_product.update(quantity: cart_product.quantity + params[:quantity].to_i)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,8 +1,6 @@
 class User < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
-  after_create :create_cart
-
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable,
          :omniauthable, omniauth_providers: %i[google_oauth2]

--- a/app/views/carts/_item.html.erb
+++ b/app/views/carts/_item.html.erb
@@ -13,7 +13,7 @@
     <%# 規格 %>
     <p class="block w-20 text-sm md:w-2/12 spec-btn"><%= cart_product.sale_info.spec %></p>
     <%# 單價 %>
-    <div class="block w-full my-2 text-sm md:mx-3 md:text-gray-900 text-marche_orange text:start md:text-center md:w-1/12">$<%= cart_product.sale_info.price %></div>
+    <div class="block w-full my-2 text-sm md:mx-3 md:text-gray-900 text-marche_orange text:start md:text-center md:w-1/12"><%= number_to_currency(cart_product.sale_info.price, precision: 0) %></div>
     <%# 數量 %>
     <div class="relative flex items-center justify-start w-full md:justify-center md:w-2/12" data-cart--item-target="inputArea">
       <button class="quantity-btn-left-arrow" data-action="click->cart--item#decrement click->cart--form#update">－</button>

--- a/app/views/carts/index.html.erb
+++ b/app/views/carts/index.html.erb
@@ -36,11 +36,8 @@
           <p class="text-sm">清空購物車</p>
         </div>
         <p class="ml-auto mr-2 text-sm">總金額<span class="hidden md:inline"> (<span data-cart--form-target="productNum">0</span> 個商品)</span> :<span class="m-2 font-semibold texy-sm md:text-lg text-marche_orange" data-cart--form-target="totalPrice">$0</span></p>
-        <% if user_signed_in? %>
-          <%= form.submit "去買單", data: {cart__form_target: "submitBtn"} ,class: "checkout-btn"%>
-        <% else %>
-          <div class="flex items-center justify-center login-link"><%= link_to '登入即可結帳', new_user_session_path, class: "" %></div>
-        <% end %>
+        <%= form.submit "去買單", data: {cart__form_target: "submitBtn", sign_in_state: user_signed_in?} ,class: "checkout-btn hidden" %>
+        <div class="flex items-center justify-center login-link" data-cart--form-target="loginLink"><%= link_to '登入即可結帳', new_user_session_path %></div>
       <% end %>
     </div>
   </section>

--- a/app/views/carts/index.html.erb
+++ b/app/views/carts/index.html.erb
@@ -1,35 +1,43 @@
-<%= render partial: 'layouts/page_header', locals: {ransack_q: @ransack_q} %>
-<section class="container w-full mx-auto my-12 border lg:w-11/12 xl:w-10/12 bg-gay-200">
-  <%= form_with url: new_order_path, method: :get, data: { turbo: "false", controller: "cart--form", cart_id: @cart.id} do |form| %>
-    <%# 標題欄區域 %>
-    <div class="flex items-center justify-start w-full bg-gray-100 h-14">
-      <p class="hidden w-36 md:inline"></p>
-      <div class="flex items-center w-10/12">
-        <p class="w-full mx-2 my-2 ml-24 text-sm text-center md:ml-0 lg:w-5/12 md:w-4/12">商品</p>
-        <p class="hidden w-2/12 text-sm md:inline"></p>
-        <p class="hidden w-1/12 my-2 text-sm text-center md:inline md:mx-3">單價</p>
-        <p class="hidden w-2/12 text-sm text-center md:inline">數量</p>
-        <p class="hidden w-1/12 mx-1 text-sm text-center md:inline">總計</p>
-        <p class="hidden w-1/12 text-sm text-center md:inline ">操作</p>
+<%= render partial: 'layouts/page_header', locals: {ransack_q: @ransack_q, user_cart_product_num: @user_cart_product_num} %>
+<% if @cart.nil? || @cart_products.blank? %>
+  <p>沒有商品拉！！！！ </p>
+<% else %>
+  <section class="container w-full mx-auto my-12 border lg:w-11/12 xl:w-10/12 bg-gay-200">
+    <%= form_with url: new_order_path, method: :get, data: { turbo: "false", controller: "cart--form", cart_id: @cart&.id} do |form| %>
+      <%# 標題欄區域 %>
+      <div class="flex items-center justify-start w-full bg-gray-100 h-14">
+        <p class="hidden w-36 md:inline"></p>
+        <div class="flex items-center w-10/12">
+          <p class="w-full mx-2 my-2 ml-24 text-sm text-center md:ml-0 lg:w-5/12 md:w-4/12">商品</p>
+          <p class="hidden w-2/12 text-sm md:inline"></p>
+          <p class="hidden w-1/12 my-2 text-sm text-center md:inline md:mx-3">單價</p>
+          <p class="hidden w-2/12 text-sm text-center md:inline">數量</p>
+          <p class="hidden w-1/12 mx-1 text-sm text-center md:inline">總計</p>
+          <p class="hidden w-1/12 text-sm text-center md:inline ">操作</p>
+        </div>
       </div>
-    </div>
-    <%# 購物車項目區域 %>
-    <%= render partial:'carts/item', collection: @cart_products , as: :cart_product%>
-    <%# 下方勾選、刪除、提交操作區域 %>
-    <div class="container flex items-center h-20 bg-gray-100">
-      <div class="flex items-center mr-3 md:mr-5 md:ml-2">
-        <input type="checkbox"
+      <%# 購物車項目區域 %>
+      <%= render partial:'carts/item', collection: @cart_products , as: :cart_product%>
+      <%# 下方勾選、刪除、提交操作區域 %>
+      <div class="container flex items-center h-20 bg-gray-100">
+        <div class="flex items-center mr-3 md:mr-5 md:ml-2">
+          <input type="checkbox"
           class="ml-3 mr-2 rounded checkbox checkbox-sm focus:outline-gray-600" data-action="change->cart--form#checkAllBox"/>
-        <p class="w-[60px] text-sm" data-cart--form-target="allProductsNum">全選 (<%= @cart_products.count %>)</p>
-      </div>
-      <div class="items-center hidden m-2 md:flex">
-        <button class="flex items-center justify-center w-5 h-5 p-2 m-2 border border-gray-500 rounded hover:bg-red-600 hover:text-white" data-action="click->cart--form#clearAllCartItems">
-          <i class="fa-solid fa-x"></i>
-        </button>
-        <p class="text-sm">清空購物車</p>
-      </div>
-      <p class="mr-2 text-sm w-fit ms-auto">總金額<span class="hidden md:inline"> (<span data-cart--form-target="productNum">0</span> 個商品)</span> :<span class="m-2 font-semibold texy-sm md:text-lg text-marche_orange" data-cart--form-target="totalPrice">$0</span></p>
-      <%= form.submit "去買單", data: {cart__form_target: "submitBtn"} ,class: "checkout-btn"%>
-    <% end %>
-  </div>
-</section>
+          <p class="w-[60px] text-sm" data-cart--form-target="allProductsNum">全選 (<%= @cart_products.count %>)</p>
+        </div>
+        <div class="items-center hidden m-2 md:flex">
+          <button class="flex items-center justify-center w-5 h-5 p-2 m-2 border border-gray-500 rounded hover:bg-red-600 hover:text-white" data-action="click->cart--form#clearAllCartItems">
+            <i class="fa-solid fa-x"></i>
+          </button>
+          <p class="text-sm">清空購物車</p>
+        </div>
+        <p class="ml-auto mr-2 text-sm">總金額<span class="hidden md:inline"> (<span data-cart--form-target="productNum">0</span> 個商品)</span> :<span class="m-2 font-semibold texy-sm md:text-lg text-marche_orange" data-cart--form-target="totalPrice">$0</span></p>
+        <% if user_signed_in? %>
+          <%= form.submit "去買單", data: {cart__form_target: "submitBtn"} ,class: "checkout-btn"%>
+        <% else %>
+          <div class="flex items-center justify-center login-link"><%= link_to '登入即可結帳', new_user_session_path, class: "" %></div>
+        <% end %>
+      <% end %>
+    </div>
+  </section>
+<% end %>

--- a/app/views/carts/index.html.erb
+++ b/app/views/carts/index.html.erb
@@ -1,6 +1,10 @@
 <%= render partial: 'layouts/page_header', locals: {ransack_q: @ransack_q, user_cart_product_num: @user_cart_product_num} %>
 <% if @cart.nil? || @cart_products.blank? %>
-  <p>沒有商品拉！！！！ </p>
+  <section class="container flex flex-col items-center justify-center h-40 mx-auto mt-16">
+    <i class="text-5xl fa-solid fa-cart-shopping text-stone-500"></i>
+    <p class="mt-2">購物車內沒有商品</p>
+    <%= link_to '來去首頁逛逛~', root_path, class: "border-b border-slate-500" %>
+  </section>
 <% else %>
   <section class="container w-full mx-auto my-12 border lg:w-11/12 xl:w-10/12 bg-gay-200">
     <%= form_with url: new_order_path, method: :get, data: { turbo: "false", controller: "cart--form", cart_id: @cart&.id} do |form| %>

--- a/app/views/carts/index.html.erb
+++ b/app/views/carts/index.html.erb
@@ -1,6 +1,6 @@
 <%= render partial: 'layouts/page_header', locals: {ransack_q: @ransack_q} %>
 <section class="container w-full mx-auto my-12 border lg:w-11/12 xl:w-10/12 bg-gay-200">
-  <%= form_with url: new_order_path, method: :get, data: { turbo: "false", controller: "cart--form", cart_id: current_user.cart.id} do |form| %>
+  <%= form_with url: new_order_path, method: :get, data: { turbo: "false", controller: "cart--form", cart_id: @cart.id} do |form| %>
     <%# 標題欄區域 %>
     <div class="flex items-center justify-start w-full bg-gray-100 h-14">
       <p class="hidden w-36 md:inline"></p>

--- a/app/views/categories/show.html.erb
+++ b/app/views/categories/show.html.erb
@@ -1,4 +1,4 @@
-<%= render partial: 'layouts/page_header', locals: {ransack_q: @ransack_q} %>
+<%= render partial: 'layouts/page_header', locals: {ransack_q: @ransack_q, user_cart_product_num: @user_cart_product_num} %>
 <%# 標題區 %>
 <div class="flex items-center w-full mt-8 mb-1 ml-2 sm:mx-auto sm:w-10/12">
   <%# 標題 %>

--- a/app/views/layouts/_page_header.html.erb
+++ b/app/views/layouts/_page_header.html.erb
@@ -15,8 +15,8 @@
   </div>
   <%# 購物車 %>
   <div class="my-2 ml-2 sm:ml-20 md:ml-10 w-28 indicator" data-controller="cart--icon" data-action="update--cart@window->cart--icon#updateCart">
-    <span class="relative left-12 top-4 px-[5px] bg-marche_white text-marche_orange indicator-item badge badge-secondary" data-cart--icon-target="cartNum" data-product-count="<%= @user_cart_product_num %>">
-      <%= @user_cart_product_num %>
+    <span class="relative left-12 top-4 px-[5px] bg-marche_white text-marche_orange indicator-item badge badge-secondary" data-cart--icon-target="cartNum" data-product-count="<%= user_cart_product_num %>">
+      <%= user_cart_product_num %>
     </span>
     <%= link_to(raw('<svg xmlns="http://www.w3.org/2000/svg" width="34" height="34" viewBox="0 0 24 24" class="mt-3 mr-3"><path d="M21.5,15a3,3,0,0,0-1.9-2.78l1.87-7a1,1,0,0,0-.18-.87A1,1,0,0,0,20.5,4H6.8L6.47,2.74A1,1,0,0,0,5.5,2h-2V4H4.73l2.48,9.26a1,1,0,0,0,1,.74H18.5a1,1,0,0,1,0,2H5.5a1,1,0,0,0,0,2H6.68a3,3,0,1,0,5.64,0h2.36a3,3,0,1,0,5.82,1,2.94,2.94,0,0,0-.4-1.47A3,3,0,0,0,21.5,15Zm-3.91-3H9L7.34,6H19.2ZM9.5,20a1,1,0,1,1,1-1A1,1,0,0,1,9.5,20Zm8,0a1,1,0,1,1,1-1A1,1,0,0,1,17.5,20Z"></path></svg>'), carts_path, class: "fill-marche_white pr-4 mb-4 ml-3") %>
   </div>

--- a/app/views/orders/new.html.erb
+++ b/app/views/orders/new.html.erb
@@ -1,58 +1,52 @@
-<%= render partial: 'layouts/page_header', locals: {ransack_q: @ransack_q} %>
-<section class="w-10/12 mx-auto my-12">  
+<%= render partial: 'layouts/page_header', locals: {ransack_q: @ransack_q, user_cart_product_num: @user_cart_product_num} %>
+<section class="w-10/12 mx-auto my-12">
   <div class="flex justify-center mt-5 mb-5">
     <h1 class="text-2xl">結帳頁面</h1>
   </div>
   <div class="m-3">
     <p class="text-xl">商品數量：<%= @cart_products.count %></p>
   </div>
-
-  <table class="border-2 text-center w-full mx-auto">
-    <tr class="border-b bg-gray-100">
-      <td class="text-lg w-3/12 border-r-2">產品名稱</td>
-      <td class="text-lg w-7/12">商品規格</td>
-      <td class="text-lg w-2/12 border-l-2">數量</td>
+  <table class="w-full mx-auto text-center border-2">
+    <tr class="bg-gray-100 border-b">
+      <td class="w-3/12 text-lg border-r-2">產品名稱</td>
+      <td class="w-7/12 text-lg">商品規格</td>
+      <td class="w-2/12 text-lg border-l-2">數量</td>
     </tr>
-
     <% @cart_products.each do |c| %>
-      <tr class="border"> 
+      <tr class="border">
         <td class="py-2"><%= c.sale_info.product.name %></td>
         <td><%= c.sale_info.spec %></td>
         <td><%= c.quantity %></td>
       </tr>
     <% end %>
   </table>
-
   <%= form_with model: @order, url: orders_path, method: :post do |form| %>
     <% @cart_products.each do |c|%>
       <%= hidden_field_tag "cart_product[]", value = c.id %>
-      <% end %>
-
+    <% end %>
     <%# 這段要讓使用者填寫收件人資訊 %>
-    <div class="border-2 mt-8">
+    <div class="mt-8 border-2">
       <div class="flex justify-center md:justify-start pl-[18px] text-lg py-[6px] border-b-2 w-full bg-gray-100">
         <p>請填寫收件人資訊</p>
       </div>
-      
-      <div class="flex flex-col items-center md:justify-around mt-8 mb-4 w-5/6 mx-auto">
-        <div class="mb-4 flex items-center justify-between w-full">
+      <div class="flex flex-col items-center w-5/6 mx-auto mt-8 mb-4 md:justify-around">
+        <div class="flex items-center justify-between w-full mb-4">
           <%= form.label :shipping_address, "配送地址", class: "ml-2 md:mr-2" %>
           <%= form.text_field :shipping_address, class: "mr-2"%>
         </div>
-        <div class="mb-4 flex items-center justify-between w-full">
+        <div class="flex items-center justify-between w-full mb-4">
           <%= form.label :receiver, "收件人", class: "ml-2 md:mr-2" %>
           <%= form.text_field :receiver, class: "mr-2" %>
         </div>
-        <div class="mb-4 flex items-center justify-between w-full">
+        <div class="flex items-center justify-between w-full mb-4">
           <%= form.label :note, "備註", class: "ml-2 md:mr-2 " %>
           <%= form.text_field :note, class: "mr-2"%>
         </div>
-        <div class="mb-4 flex items-center justify-center md:justify-around w-full md:w-auto">
-          <p class="text-red-600 text-base">僅供宅配</p>
+        <div class="flex items-center justify-center w-full mb-4 md:justify-around md:w-auto">
+          <p class="text-base text-red-600">僅供宅配</p>
         </div>
       </div>
-    
-      <div class="flex flex-wrap justify-end items-center pr-2 mt-4 pl-2 bg-gray-100 border-2 border-b-0 border-x-0">
+      <div class="flex flex-wrap items-center justify-end pl-2 pr-2 mt-4 bg-gray-100 border-2 border-b-0 border-x-0">
         <%= link_to "上一頁", :back, class: "mr-auto border text-green-500 bg-green-50 hover:cursor-pointer p-2 m-2 rounded hover:bg-green-100" %>
         <p class="mx-6 text-lg text-red-600">本次結帳金額為 <%= number_to_currency(@total_price, precision: 0) %> </p>
         <%= form.submit "金額確認，產生訂單", class: "border text-green-500 bg-green-50 hover:cursor-pointer p-2 m-2 rounded hover:bg-green-100" %>

--- a/app/views/products/_info.html.erb
+++ b/app/views/products/_info.html.erb
@@ -40,6 +40,6 @@
         <p data-product--cart-product-target="storage" class="text-base text-gray-500">還剩<%= sale_info.storage%>件</p>
       </div>
     </div >
-    <%= form.submit "加入購物車", class: "w-full bg-marche_orange text-white px-4 py-2 rounded-xs hover:bg-orange-600 rounded-md", data: { action: "click->product--cart-product#send"}, remote: true %>
+    <%= form.submit "加入購物車", class: "cursor-pointer w-full bg-marche_orange text-white px-4 py-2 rounded-xs hover:bg-orange-600 rounded-md", data: { action: "click->product--cart-product#send"}, remote: true %>
   <% end %>
 </section>

--- a/app/views/products/index.html.erb
+++ b/app/views/products/index.html.erb
@@ -1,4 +1,4 @@
-<%= render partial: 'layouts/page_header', locals: {ransack_q: @ransack_q} %>
+<%= render partial: 'layouts/page_header', locals: {ransack_q: @ransack_q, user_cart_product_num: @user_cart_product_num} %>
 <%= render 'shared/flash' if flash.any? %>
 <%# Banner%>
 <div class="container w-full mx-auto my-10 sm:w-10/12">
@@ -25,9 +25,6 @@
     </div>
   </div>
 </div>
-
-
-
 <%# 商品分類 %>
 <section class="flex flex-col w-full mx-auto my-6 sm:w-10/12">
   <h2 class="self-start pl-2 text-xl font-bold text-marche_orange sm:pl-0">商品分類</h2>

--- a/app/views/products/search.html.erb
+++ b/app/views/products/search.html.erb
@@ -1,4 +1,4 @@
-<%= render partial: 'layouts/page_header', locals: {ransack_q: @ransack_q} %>
+<%= render partial: 'layouts/page_header', locals: {ransack_q: @ransack_q, user_cart_product_num: @user_cart_product_num} %>
 <section class="w-9/12 mx-auto" data-controller="product--order" data-recent-order="<%= @recent_order%>">
   <%# 標題 %>
   <h1 class="mt-8 mb-1 mr-4 text-xl font-bold text-marche_black">搜尋結果：<%= @search_keyword %> </h1>

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -1,4 +1,4 @@
-<%= render partial: 'layouts/page_header', locals: {ransack_q: @ransack_q} %>
+<%= render partial: 'layouts/page_header', locals: {ransack_q: @ransack_q, user_cart_product_num: @user_cart_product_num} %>
 <div class="flex max-w-2xl mx-auto">
   <div class="w-full mx-auto">
     <div class="w-full p-2 mx-auto mt-3">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,7 @@ Rails.application.routes.draw do
   devise_for :users, controllers: { 
     omniauth_callbacks: 'users/omniauth_callbacks',
     registrations: 'users/registrations',
+    sessions: 'users/sessions'
   }
 
   get '/users/liked_products', to: 'users#show_like', as: :show_like # 收藏商品


### PR DESCRIPTION
[影片](https://youtu.be/0-atoOBGgtQ)
使用session記錄新創建的無頭購物車。
- 使用者本站登入or第三方登入時：將無頭購物車的資料轉移至使用者原本的購物車中，並判斷有沒有重複的商品項目，重複的商品項目要修改該商品的數量
- 使用者本站註冊or第三方註冊時：將無頭購物車直接指定給新使用者
- 使用者在登入or註冊後，會將原先的session刪除，不需要用到的資料也進行刪除
- 使用者在購物車的頁面中，如果是尚未登入的狀態下，結帳按鈕將換成登入即可結帳按鈕，將使用者導到登入頁面
- 使用者在登入後會回到原先的購物車頁面
- 如果購物車中沒有任何商品，會有頁面提示購物車中沒有商品，並附上回到首頁的超連結