### PR TITLE
feat: Add status translation methods

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,11 +1,20 @@
 module ApplicationHelper
   include Pagy::Frontend
 
-  def shipped(shipping_status)
-    if shipping_status == "not_shipped"
-      return "未出貨"
-    else
-      return "已出貨"
-    end
+  def translate_payment_status(payment_status)
+    translations = {
+    "pending" => "未付款",
+    "paid" => "已付款"
+    }
+    translations[payment_status]
+  end
+
+  def translate_shipping_status(shipping_status)
+    translations = {
+    "pending" => "未出貨",
+    "shipped" => "已出貨",
+    "not_shipped" => "未出貨"
+    }
+    translations[shipping_status]
   end
 end

--- a/app/views/orders/_order.html.erb
+++ b/app/views/orders/_order.html.erb
@@ -12,7 +12,7 @@
   </div>
   <div class="flex justify-around px-3 pt-1 m-2">
     <p class="w-1/2 text-left">付款狀態</p>
-    <p class="w-1/2 text-left"><%= order.payment_status %></p>
+    <p class="w-1/2 text-left"><%= translate_payment_status(order.payment_status) %></p>
   </div>
   <div class="flex justify-around px-3 pt-1 m-2">
     <p class="w-1/2 text-left">付款方式</p>
@@ -29,7 +29,7 @@
   </section>
   <div class="flex justify-around px-3 pt-1 m-2">
     <p class="w-1/2 mt-1 text-left">出貨狀態</p>
-    <p class="w-1/2 text-left"><%= order.shipping_status %></p>
+    <p class="w-1/2 text-left"><%= translate_shipping_status(order.shipping_status) %></p>
   </div>
   <div class="flex justify-around px-3 pt-1 m-2">
     <p class="w-1/2 text-left">配送地址</p>

--- a/app/views/orders/paid.html.erb
+++ b/app/views/orders/paid.html.erb
@@ -1,10 +1,10 @@
 <%# render partial: 'layouts/page_header', locals: {ransack_q: @ransack_q} %>
 <%= render 'shared/paid' if flash.any? %>
 <section class="w-10/12 mx-auto mt-10 mb-20 border-2">
-  <div class="flex justify-center border-b-2 bg-gray-100">
+  <div class="flex justify-center bg-gray-100 border-b-2">
     <h1 class="m-2 text-xl">訂單資訊</h1>
   </div>
-  <div class="flex justify-around px-3 pt-2 items-center">
+  <div class="flex items-center justify-around px-3 pt-2">
     <p class="w-1/2 text-lg text-center">訂單編號</p>
     <p class="w-1/2 text-lg text-center break-words"><%= @order.tracking_number %></p>
   </div>
@@ -12,10 +12,10 @@
   <div class="flex justify-around px-3 pt-2">
     <% if @order.payment_status == "paid" %>
       <p class="w-1/2 text-lg text-center">付款狀態</p>
-      <p class="w-1/2 text-lg text-center"><%= @order.payment_status %></p>
+      <p class="w-1/2 text-lg text-center"><%= translate_payment_status(@order.payment_status) %></p>
     <% else %>
-      <p class="w-1/2 text-lg text-center font-bold text-red-600">付款狀態</p>
-      <p class="w-1/2 text-lg text-center font-bold text-red-600">付款失敗</p>
+      <p class="w-1/2 text-lg font-bold text-center text-red-600">付款狀態</p>
+      <p class="w-1/2 text-lg font-bold text-center text-red-600">付款失敗</p>
     <% end %>
   </div>
 
@@ -23,14 +23,14 @@
     <p class="w-1/2 text-lg text-center">付款方式</p>
     <p class="w-1/2 text-lg text-center">信用卡</p>
   </div>
-  <div class="flex justify-around px-3 pt-2 items-center">
+  <div class="flex items-center justify-around px-3 pt-2">
     <p class="w-1/2 text-xl text-center text-red-600">總價</p>
     <p class="w-1/2 text-xl text-center text-red-600 break-words"><%= number_to_currency(@order.total_price, precision: 0) %></p>
   </div>
 
       <%# 分隔線 %>
   <div class="flex justify-center m-3">
-    <div class="border-b w-4/5"></div>
+    <div class="w-4/5 border-b"></div>
   </div>
 
   <% if @order.payment_status == "pending" %>
@@ -41,19 +41,19 @@
       <input type="hidden" id="TradeSha" name="TradeSha" value="<%= @form_info[:TradeSha] %>">
       <input type="hidden" id="Version" name="Version" value="<%= @form_info[:Version] %>">
       <%# 客戶資訊 %>
-      <div class="flex justify-around px-3 pt-2 items-center">
+      <div class="flex items-center justify-around px-3 pt-2">
         <p class="w-1/2 text-lg text-center">收件人</p>
         <p class="w-1/2 text-lg text-center break-words"><%= @order.receiver %></p>
       </div>
-      <div class="flex justify-around px-3 pt-2 items-center">
+      <div class="flex items-center justify-around px-3 pt-2">
         <p class="w-1/2 text-lg text-center">配送地址</p>
         <p class="w-1/2 text-lg text-center break-words"><%= @order.shipping_address %></p>
       </div>
-      <div class="flex justify-around px-3 p-2">
+      <div class="flex justify-around p-2 px-3">
         <p class="w-1/2 text-lg text-center">配送方式</p>
         <p class="w-1/2 text-lg text-center">宅配</p>
       </div>
-      <div class="flex justify-around px-3 p-2 items-center">
+      <div class="flex items-center justify-around p-2 px-3">
         <p class="w-1/2 text-lg text-center">備註</p>
         <p class="w-1/2 text-lg text-center break-words"><%= @order.note %></p>
       </div>
@@ -67,11 +67,11 @@
       </div>
     <% end %>
   <% else %>
-    <div class="flex justify-around pt-2 py-4 ">
-      <div class="text-center w-1/2 px-3">
+    <div class="flex justify-around py-4 pt-2 ">
+      <div class="w-1/2 px-3 text-center">
         <%= link_to "首頁", root_path, class: "border text-green-500 text-lg bg-green-50 hover:cursor-pointer p-2 rounded hover:bg-green-100" %>
       </div>
-      <div class="text-center w-1/2 px-3">
+      <div class="w-1/2 px-3 text-center">
         <%= link_to "查看所有訂單", orders_path, class: "border text-green-500 text-lg bg-green-50 hover:cursor-pointer p-2 rounded hover:bg-green-100" %>
       </div>
     </div>

--- a/app/views/orders/show.html.erb
+++ b/app/views/orders/show.html.erb
@@ -1,4 +1,4 @@
-<%= render partial: 'layouts/page_header', locals: {ransack_q: @ransack_q} %>
+<%= render partial: 'layouts/page_header', locals: {ransack_q: @ransack_q, user_cart_product_num: @user_cart_product_num} %>
 <%= render 'shared/flash' if flash.any? %>
 <%# 這段是要送給藍新的資訊%>
 <%= form_with(url: 'https://ccore.newebpay.com/MPG/mpg_gateway', method: "post") do |form| %>
@@ -7,34 +7,34 @@
   <input type="hidden" id="TradeSha" name="TradeSha" value="<%= @form_info[:TradeSha] %>">
   <input type="hidden" id="Version" name="Version" value="<%= @form_info[:Version] %>">
   <%# 客戶資訊 %>
-  <section class="border-2 my-20 mx-auto w-10/12">
+  <section class="w-10/12 mx-auto my-20 border-2">
     <div class="flex justify-center p-2 bg-gray-100 border-b">
       <p class="text-lg">配送資訊</p>
     </div>
-    <div class="flex justify-around items-center px-2 pt-4">
+    <div class="flex items-center justify-around px-2 pt-4">
       <p class="w-1/2 text-base text-center">收件人</p>
       <p class="w-1/2 text-base text-center break-words"><%= @order.receiver %></p>
     </div>
-    <div class="flex justify-around items-center px-2 pt-2">
+    <div class="flex items-center justify-around px-2 pt-2">
       <p class="w-1/2 text-base text-center">配送地址</p>
       <p class="w-1/2 text-base text-center break-words"><%= @order.shipping_address %></p>
     </div>
-    <div class="flex justify-around items-center px-2 p-2">
+    <div class="flex items-center justify-around p-2 px-2">
       <p class="w-1/2 text-base text-center">配送方式</p>
       <p class="w-1/2 text-base text-center ">宅配</p>
     </div>
-    <div class="flex justify-around items-center px-2 pb-4">
+    <div class="flex items-center justify-around px-2 pb-4">
       <p class="w-1/2 text-base text-center">備註</p>
       <p class="w-1/2 text-base text-center break-words"><%= @order.note %></p>
     </div>
-    <div class="flex justify-around items-center px-2 pb-4">
+    <div class="flex items-center justify-around px-2 pb-4">
       <p class="w-1/2 text-xl text-center text-red-600">總價</p>
       <p class="w-1/2 text-xl text-center text-red-600"><%=  number_to_currency(@order.total_price, precision: 0) %></p>
     </div>
 
       <%# 分隔線 %>
     <div class="flex justify-center m-2">
-      <div class="border w-4/5"></div> 
+      <div class="w-4/5 border"></div> 
     </div>
 
     <div class="flex justify-around mb-2">

--- a/app/views/shops/order.html.erb
+++ b/app/views/shops/order.html.erb
@@ -23,7 +23,7 @@
         <tbody>
           <% @shop_orders.each_with_index do |shop_orders, index| %>
             <tr class="text-center hover" data-controller="shop--order" data-order-product-id="<%= shop_orders.id %>"> 
-              <td data-shop--order-traget="status"><%= shipped(shop_orders.shipping_status) %></td>
+              <td data-shop--order-traget="status"><%= translate_shipping_status(shop_orders.shipping_status) %></td>
               <td><%= format_date_with_time(shop_orders.updated_at) %></td>
               <td><%= shop_orders.product.name %></td>
               <td><%= shop_orders.spec %></td>

--- a/app/views/shops/shipped.html.erb
+++ b/app/views/shops/shipped.html.erb
@@ -23,7 +23,7 @@
         <tbody>
           <% @shop_orders.each_with_index do |shop_orders, index| %>
             <tr class="text-center hover" data-controller="shop--order" data-order-product-id="<%= shop_orders.id %>"> 
-              <td data-shop--order-traget="status"><%= shipped(shop_orders.shipping_status) %></td>
+              <td data-shop--order-traget="status"><%= translate_shipping_status(shop_orders.shipping_status) %></td>
               <td><%= format_date_with_time(shop_orders.created_at) %></td>
               <td><%= format_date_with_time(shop_orders.updated_at) %></td>
               <td><%= shop_orders.product.name %></td>


### PR DESCRIPTION
This commit introduces two new methods, `translate_payment_status` and `translate_shipping_status,` which are responsible for translating the status values from English to Chinese. These methods use a hash-based approach for mapping the status values to their corresponding translations.


![Screen Shot 0005-05-22 at 18 57 10](https://github.com/5xRuby13thMarche/Marche/assets/112312121/2d3cac9f-2a60-42de-ba3b-78f5ac81c875)
![Screen Shot 0005-05-22 at 18 58 28](https://github.com/5xRuby13thMarche/Marche/assets/112312121/673a76c5-4bc3-48c1-a744-f1d9ba2bb093)

