### PR TITLE
建議購物車的圖示，要訂在上方，不要因為滾輪而消失

### DIFF
--- a/app/javascript/controllers/cart/item_controller.js
+++ b/app/javascript/controllers/cart/item_controller.js
@@ -110,7 +110,7 @@ export default class extends Controller {
   showDeleteToast() {
     const Toast = Swal.mixin({
       toast: true,
-      position: "top-end",
+      position: "top-start",
       showConfirmButton: false,
       timer: 3000,
       timerProgressBar: false,

--- a/app/javascript/controllers/flash_controller.js
+++ b/app/javascript/controllers/flash_controller.js
@@ -7,7 +7,7 @@ export default class extends Controller {
   connect() {
     const Toast = Swal.mixin({
       toast: true,
-      position: 'top',
+      position: 'top-start',
       showConfirmButton: false,
       timer: 3000,
       timerProgressBar: true,

--- a/app/views/layouts/_page_header.html.erb
+++ b/app/views/layouts/_page_header.html.erb
@@ -1,4 +1,4 @@
-<header class="mt-7 fixed z-50 flex items-center justify-center md:justify-between w-full px-6 bg-marche_orange 2xl:px-[136px] xl:px-32 lg:px-[116px] md:px-28 sm:px-14">
+<header class="mt-7 fixed z-20 flex items-center justify-center md:justify-between w-full px-6 bg-marche_orange 2xl:px-[136px] xl:px-32 lg:px-[116px] md:px-28 sm:px-14">
   <section class="hidden my-2 mr-2 md:block link link-hover md:min-w-fit">
     <%= link_to root_path do%>
       <%= image_tag "marche_logo_home.svg" ,class: "h-12 mb-1" %>

--- a/app/views/orders/new.html.erb
+++ b/app/views/orders/new.html.erb
@@ -1,5 +1,5 @@
 <%= render partial: 'layouts/page_header', locals: {ransack_q: @ransack_q, user_cart_product_num: @user_cart_product_num} %>
-<section class="w-10/12 mx-auto my-12">
+<section class="w-10/12 mx-auto my-12 mt-32">
   <div class="flex justify-center mt-5 mb-5">
     <h1 class="text-2xl">結帳頁面</h1>
   </div>
@@ -29,16 +29,16 @@
       <div class="flex justify-center md:justify-start pl-[18px] text-lg py-[6px] border-b-2 w-full bg-gray-100">
         <p>請填寫收件人資訊</p>
       </div>
-      <div class="flex flex-col md:flex-row md:flex-wrap items-center w-5/6 mx-auto mt-8 mb-4 md:justify-around">
-        <div class="flex flex-col md:flex-row items-center justify-between w-full mb-4  ">
+      <div class="flex flex-col items-center w-5/6 mx-auto mt-8 mb-4 md:flex-row md:flex-wrap md:justify-around">
+        <div class="flex flex-col items-center justify-between w-full mb-4 md:flex-row ">
           <%= form.label :shipping_address, "配送地址", class: "ml-2 md:mr-2" %>
           <%= form.text_field :shipping_address, class: "mr-2"%>
         </div>
-        <div class="flex flex-col md:flex-row items-center justify-between w-full mb-4">
+        <div class="flex flex-col items-center justify-between w-full mb-4 md:flex-row">
           <%= form.label :receiver, "收件人", class: "ml-2 md:mr-2" %>
           <%= form.text_field :receiver, class: "mr-2" %>
         </div>
-        <div class="flex flex-col md:flex-row items-center justify-between w-full mb-4">
+        <div class="flex flex-col items-center justify-between w-full mb-4 md:flex-row">
           <%= form.label :note, "備註", class: "ml-2 md:mr-2 " %>
           <%= form.text_field :note, class: "mr-2"%>
         </div>

--- a/app/views/orders/paid.html.erb
+++ b/app/views/orders/paid.html.erb
@@ -1,6 +1,6 @@
 <%# render partial: 'layouts/page_header', locals: {ransack_q: @ransack_q} %>
 <%= render 'shared/paid' if flash.any? %>
-<section class="w-10/12 mx-auto mt-10 mb-20 border-2">
+<section class="w-10/12 mx-auto mt-12 mb-20 border-2">
   <div class="flex justify-center bg-gray-100 border-b-2">
     <h1 class="m-2 text-xl">訂單資訊</h1>
   </div>

--- a/app/views/orders/show.html.erb
+++ b/app/views/orders/show.html.erb
@@ -7,7 +7,7 @@
   <input type="hidden" id="TradeSha" name="TradeSha" value="<%= @form_info[:TradeSha] %>">
   <input type="hidden" id="Version" name="Version" value="<%= @form_info[:Version] %>">
   <%# 客戶資訊 %>
-  <section class="w-10/12 mx-auto my-20 border-2">
+  <section class="w-10/12 mx-auto my-20 mt-40 border-2">
     <div class="flex justify-center p-2 bg-gray-100 border-b">
       <p class="text-lg">配送資訊</p>
     </div>

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -1,4 +1,4 @@
-<div class="fixed z-50 flex w-full bg-marche_orange">
+<div class="fixed z-30 flex w-full bg-marche_orange">
   <nav class="w-full items-center flex flex-wrap justify-end content-center mx-[30px] 2xl:mx-[140px] xl:mx-[132px] lg:mx-[120px] md:mx-[116px] sm:mx-[60px]">
     <% if current_user&.shop&.present? %>
       <%= link_to "賣家中心", shops_path , class: "hidden md:inline-block text-gray-100 text-xs mr-auto"%>
@@ -20,7 +20,7 @@
           <%= avatar(current_user, size: [100, 100]) %>
         </div>
       </label>
-      <ul tabindex="0" class="p-2 shadow menu menu-compact dropdown-content bg-base-100 rounded-box w-60">
+      <ul tabindex="0" class="z-40 p-2 shadow menu menu-compact dropdown-content bg-base-100 rounded-box w-60">
         <% if user_signed_in? %>
           <li class="py-1 pl-4 text-marche_orange text-md"><%= current_user.email %></li>
           <li>

--- a/app/views/shared/_paid.html.erb
+++ b/app/views/shared/_paid.html.erb
@@ -1,9 +1,9 @@
 <% if flash[:notice] %>
   <div class="flex justify-center">
-    <p class="inline-block px-3 text-center md:w-9/12 max-w-[300px] py-2 mt-5 text-lg text-white rounded-lg bg-marche_orange" id="notice"><%= flash[:notice] %></p>
+    <p class="inline-block px-3 text-center md:w-9/12 max-w-[300px] py-2 mt-16 text-xl text-marche_orange font-bold" id="notice"><%= flash[:notice] %></p>
   </div>
 <% elsif flash[:alert]%>
   <div class="flex justify-center">
-    <p class="inline-block px-3 text-center md:w-9/12 max-w-[300px] py-2 mt-5 text-lg text-red-500 rounded-lg bg-red-50" id="notice"><%= flash[:alert] %></p>
+    <p class="inline-block px-3 text-center md:w-9/12 max-w-[300px] py-2 mt-16 text-xl text-red-500 font-bold" id="notice"><%= flash[:alert] %></p>
   </div>
 <% end %>


### PR DESCRIPTION
1. navbar 已固定在畫面最上方
2. 修改navbar層級，修正會員下拉選單會被navbar蓋住問題
3. 修改結帳、訂單、交易結束頁面位置
4. 將sweetalert彈出視窗位置調整至右上方
https://github.com/5xRuby13thMarche/Marche/assets/130286574/0dd9f0ed-a86e-4c0e-94f3-337d9b3227cf

