### PR TITLE
feat: Reduce sale_info storage while creating order

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,7 +2,7 @@ class ApplicationController < ActionController::Base
   rescue_from ActionController::RoutingError, with: :render_404
   rescue_from ActiveRecord::RecordNotFound, with: :render_404
   rescue_from AbstractController::ActionNotFound, with: :render_404
-  rescue_from StandardError, with: :render_500
+  rescue_from StandardError, with: :render_500  
 
   include Pagy::Backend
 

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -19,10 +19,13 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
         cart.update(user_id: @user.id)
         session.delete(:_cart_)
         redirect_to carts_path
-      else
+      elsif @user.cart.nil? && session[:_cart_].nil?
         # 生成購物車給新使用者
         @user.build_cart()
         @user.save
+        redirect_to root_path
+      else
+        # 舊使用者，沒有session
         redirect_to root_path
       end
       # sign_in_and_redirect @user, event: :authentication # this will throw if @user is not activated

--- a/app/javascript/controllers/cart/form_controller.js
+++ b/app/javascript/controllers/cart/form_controller.js
@@ -62,6 +62,7 @@ export default class extends Controller {
     } else {
       this.isAllChecked = true;
       for (let i = 0; i < this.checkboxTargets.length; i++) {
+        if (this.checkboxTargets[i].hasAttribute("disabled")) continue;
         this.checkboxTargets[i].checked = true;
       }
     }

--- a/app/models/cart_product.rb
+++ b/app/models/cart_product.rb
@@ -14,6 +14,21 @@ class CartProduct < ApplicationRecord
     end
   end
 
+  def self.check_storage(cart_products)
+    cart_products.each do |cart_product|
+      return false if cart_product.sale_info.storage < cart_product.quantity || cart_product.sale_info.storage == 0
+    end
+    return true
+  end
+
+  def self.reduce_storage(cart_products)
+    cart_products.each do |cart_product|
+      storage = cart_product.sale_info.storage -= cart_product.quantity
+      storage = (storage >=0 ) ? storage : 0
+      cart_product.sale_info.update(storage: storage)
+    end
+  end
+
   private
 
   def self.create_or_update_cart_product(cart, params)

--- a/app/views/carts/index.html.erb
+++ b/app/views/carts/index.html.erb
@@ -1,4 +1,5 @@
 <%= render partial: 'layouts/page_header', locals: {ransack_q: @ransack_q, user_cart_product_num: @user_cart_product_num} %>
+<%= render 'shared/flash' if flash.any? %>
 <% if @cart.nil? || @cart_products.blank? %>
   <section class="container flex flex-col items-center justify-center h-40 mx-auto mt-16">
     <i class="text-5xl fa-solid fa-cart-shopping text-stone-500"></i>


### PR DESCRIPTION
- 當買家成立訂單時，商品庫存減少
- 購物車中無法選擇庫存為0的商品，就算勾選全選按鈕也一樣
- 結帳頁面的後端會防堵商品選購數量超過庫存
- 修復google帳號登入時原先購物車被清除的bug

<img width="810" alt="截圖 2023-05-24 下午2 34 37" src="https://github.com/5xRuby13thMarche/Marche/assets/71165941/b89816f5-245f-4468-9a18-1277743f4291">
